### PR TITLE
Allow configurable chat message retention

### DIFF
--- a/app/Console/Commands/CleanOldChatMessages.php
+++ b/app/Console/Commands/CleanOldChatMessages.php
@@ -3,17 +3,19 @@
 namespace App\Console\Commands;
 
 use App\Models\ChatMessage;
+use App\Models\Setting;
 use Illuminate\Console\Command;
 
 class CleanOldChatMessages extends Command
 {
     protected $signature = 'chat:clean';
 
-    protected $description = 'Delete chat messages older than 30 days';
+    protected $description = 'Delete chat messages older than configured retention period';
 
     public function handle(): int
     {
-        $deleted = ChatMessage::where('created_at', '<', now()->subDays(30))->delete();
+        $days = Setting::get('chat_retention_days', config('chat.retention_days'));
+        $deleted = ChatMessage::where('created_at', '<', now()->subDays($days))->delete();
         $this->info("Deleted {$deleted} old chat messages.");
         return Command::SUCCESS;
     }

--- a/app/Livewire/Admin/Chat.php
+++ b/app/Livewire/Admin/Chat.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Admin;
 
 use App\Models\ChatMessage;
 use App\Models\User;
+use App\Models\Setting;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
@@ -108,6 +109,7 @@ class Chat extends Component
             'users' => User::where('id', '!=', Auth::id())->get(),
             'messages' => $messages,
             'messageCounts' => $messageCounts,
+            'retentionDays' => Setting::get('chat_retention_days', config('chat.retention_days')),
         ]);
     }
 }

--- a/app/Livewire/Admin/Settings.php
+++ b/app/Livewire/Admin/Settings.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Livewire\Admin;
+
+use App\Models\Setting;
+use Livewire\Component;
+
+class Settings extends Component
+{
+    public $chat_retention_days;
+
+    protected $rules = [
+        'chat_retention_days' => 'required|integer|min:1',
+    ];
+
+    public function mount(): void
+    {
+        $this->chat_retention_days = Setting::get('chat_retention_days', config('chat.retention_days'));
+    }
+
+    public function save(): void
+    {
+        $this->validate();
+        Setting::set('chat_retention_days', $this->chat_retention_days);
+        session()->flash('status', 'Settings updated');
+    }
+
+    public function render()
+    {
+        return view('livewire.admin.settings');
+    }
+}
+

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Cache;
+
+class Setting extends Model
+{
+    public $timestamps = false;
+
+    protected $fillable = [
+        'key',
+        'value',
+    ];
+
+    public static function get(string $key, $default = null)
+    {
+        return Cache::rememberForever("setting:{$key}", function () use ($key) {
+            return static::where('key', $key)->value('value');
+        }) ?? $default;
+    }
+
+    public static function set(string $key, $value): void
+    {
+        static::updateOrCreate(['key' => $key], ['value' => $value]);
+        Cache::forget("setting:{$key}");
+    }
+}
+

--- a/config/chat.php
+++ b/config/chat.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'retention_days' => env('CHAT_RETENTION_DAYS', 30),
+];
+

--- a/database/migrations/2025_08_14_231806_create_settings_table.php
+++ b/database/migrations/2025_08_14_231806_create_settings_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->text('value')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('settings');
+    }
+};
+

--- a/resources/views/livewire/admin/chat.blade.php
+++ b/resources/views/livewire/admin/chat.blade.php
@@ -1,5 +1,6 @@
 <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6 mt-6">
     <h3 class="text-lg font-semibold mb-4 text-gray-800 dark:text-white">Chat</h3>
+    <p class="text-xs text-gray-500 dark:text-gray-400 mb-4">Messages are kept for {{ $retentionDays }} days and removed automatically.</p>
 
     <div class="flex h-72">
         <div class="w-1/3 pr-4 border-r border-gray-200 dark:border-gray-700 overflow-y-auto h-full">

--- a/resources/views/livewire/admin/partials/header.blade.php
+++ b/resources/views/livewire/admin/partials/header.blade.php
@@ -17,7 +17,7 @@
             </button>
             <div id="userMenu" class="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-700 rounded-lg shadow-xl py-1 z-10 hidden">
                 <a href="#" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600">Profile</a>
-                <a href="#" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600">Settings</a>
+                <a href="{{ route('admin.settings') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600">Settings</a>
                 <hr class="border-gray-200 dark:border-gray-600 my-1">
                 <a href="#" class="block px-4 py-2 text-sm text-red-500 hover:bg-gray-100 dark:hover:bg-gray-600">Logout</a>
             </div>

--- a/resources/views/livewire/admin/settings.blade.php
+++ b/resources/views/livewire/admin/settings.blade.php
@@ -1,0 +1,16 @@
+<div class="max-w-lg mx-auto">
+    @if (session()->has('status'))
+        <div class="mb-4 text-green-600">{{ session('status') }}</div>
+    @endif
+
+    <form wire:submit.prevent="save" class="space-y-4">
+        <div>
+            <label class="block text-sm font-medium mb-1">Chat retention days</label>
+            <input type="number" min="1" wire:model="chat_retention_days" class="w-full border rounded p-2">
+            @error('chat_retention_days')
+                <div class="text-red-600 text-sm">{{ $message }}</div>
+            @enderror
+        </div>
+        <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded">Save</button>
+    </form>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Livewire\Admin\Dashboard;
 use App\Livewire\Admin\Questions\Index;
 use App\Livewire\Admin\Questions\Create;
 use App\Livewire\Admin\Questions\Edit;
+use App\Livewire\Admin\Settings;
 use App\Livewire\Admin\Subjects\Index as SubjectIndex;
 use App\Livewire\Admin\Subjects\Create as SubjectCreate;
 use App\Livewire\Admin\Subjects\Edit as SubjectEdit;
@@ -36,6 +37,9 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::get('/admin/chapters', ChapterIndex::class)->name('admin.chapters.index');
     Route::get('/admin/chapters/create', ChapterCreate::class)->name('admin.chapters.create');
     Route::get('/admin/chapters/{chapter}/edit', ChapterEdit::class)->name('admin.chapters.edit');
+
+    // Settings
+    Route::get('/admin/settings', Settings::class)->name('admin.settings');
 
     // Students
     // Route::get('/admin/students', StudentIndex::class)->name('admin.students.index');


### PR DESCRIPTION
## Summary
- make chat retention configurable and default to 30 days
- add admin setting form for chat retention
- show retention policy in chat UI and use setting in cleanup command

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68a7320b54ac8326afcee9ee3d87b328