### PR TITLE
Add configurable chat message length setting

### DIFF
--- a/app/Livewire/Admin/Chat.php
+++ b/app/Livewire/Admin/Chat.php
@@ -15,10 +15,15 @@ class Chat extends Component
     public $message = '';
     public $recipient_id = '';
 
-    protected $rules = [
-        'recipient_id' => 'required|exists:users,id',
-        'message' => 'required|string|max:500',
-    ];
+    protected function rules(): array
+    {
+        $max = Setting::get('chat_message_max_length', config('chat.message_max_length'));
+
+        return [
+            'recipient_id' => 'required|exists:users,id',
+            'message' => 'required|string|max:' . $max,
+        ];
+    }
 
     public function send()
     {

--- a/app/Livewire/Admin/Settings.php
+++ b/app/Livewire/Admin/Settings.php
@@ -8,20 +8,24 @@ use Livewire\Component;
 class Settings extends Component
 {
     public $chat_retention_days;
+    public $chat_message_max_length;
 
     protected $rules = [
         'chat_retention_days' => 'required|integer|min:1',
+        'chat_message_max_length' => 'required|integer|min:1',
     ];
 
     public function mount(): void
     {
         $this->chat_retention_days = Setting::get('chat_retention_days', config('chat.retention_days'));
+        $this->chat_message_max_length = Setting::get('chat_message_max_length', config('chat.message_max_length'));
     }
 
     public function save(): void
     {
         $this->validate();
         Setting::set('chat_retention_days', $this->chat_retention_days);
+        Setting::set('chat_message_max_length', $this->chat_message_max_length);
         session()->flash('status', 'Settings updated');
     }
 

--- a/config/chat.php
+++ b/config/chat.php
@@ -2,5 +2,6 @@
 
 return [
     'retention_days' => env('CHAT_RETENTION_DAYS', 30),
+    'message_max_length' => env('CHAT_MESSAGE_MAX_LENGTH', 500),
 ];
 

--- a/resources/views/livewire/admin/settings.blade.php
+++ b/resources/views/livewire/admin/settings.blade.php
@@ -11,6 +11,13 @@
                 <div class="text-red-600 text-sm">{{ $message }}</div>
             @enderror
         </div>
+        <div>
+            <label class="block text-sm font-medium mb-1">Chat message max length</label>
+            <input type="number" min="1" wire:model="chat_message_max_length" class="w-full border rounded p-2">
+            @error('chat_message_max_length')
+                <div class="text-red-600 text-sm">{{ $message }}</div>
+            @enderror
+        </div>
         <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded">Save</button>
     </form>
 </div>

--- a/tests/Feature/ChatTest.php
+++ b/tests/Feature/ChatTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Livewire\Admin\Chat;
 use App\Models\User;
 use App\Models\ChatMessage;
+use App\Models\Setting;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
 use Livewire\Livewire;
@@ -65,5 +66,21 @@ class ChatTest extends TestCase
             });
 
         $this->assertNotNull(ChatMessage::first()->fresh()->read_at);
+    }
+
+    public function test_message_respects_max_length_setting(): void
+    {
+        $sender = User::factory()->create();
+        $recipient = User::factory()->create();
+
+        Setting::set('chat_message_max_length', 5);
+
+        $this->actingAs($sender);
+
+        Livewire::test(Chat::class)
+            ->set('recipient_id', $recipient->id)
+            ->set('message', 'toolong')
+            ->call('send')
+            ->assertHasErrors(['message' => 'max']);
     }
 }


### PR DESCRIPTION
## Summary
- allow admins to configure chat message max length alongside retention days
- enforce message length limit in admin chat using setting
- cover chat message length setting with feature test

## Testing
- ⚠️ `composer install` *(dependency download failed: CONNECT tunnel failed, response 403)*
- ⚠️ `composer test` *(missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68a73f46e45083269e8465b3770abe9d