### PR TITLE
Show toast after chat message sent

### DIFF
--- a/resources/views/livewire/admin/chat.blade.php
+++ b/resources/views/livewire/admin/chat.blade.php
@@ -66,7 +66,19 @@
 
             scroll();
 
-            Livewire.on('chat-message-sent', scroll);
+            Livewire.on('chat-message-sent', () => {
+                scroll();
+                if (window.Swal) {
+                    Swal.fire({
+                        toast: true,
+                        icon: 'success',
+                        title: 'Message sent',
+                        position: 'top-end',
+                        showConfirmButton: false,
+                        timer: 1500,
+                    });
+                }
+            });
         });
     </script>
 @endpush


### PR DESCRIPTION
## Summary
- Show success toast after admin sends chat message

## Testing
- `npm run build`
- `composer test` *(fails: vendor/autoload.php missing)*


------
https://chatgpt.com/codex/tasks/task_e_68a74255e9c48326a38eabe17c5e62e5