### PR TITLE
Add landing routes and enhance frontend design

### DIFF
--- a/resources/views/frontend/landing.blade.php
+++ b/resources/views/frontend/landing.blade.php
@@ -6,4 +6,26 @@
     <p class="text-lg text-gray-600 mb-8">Practice and create multiple choice questions effortlessly.</p>
     <a href="{{ route('register') }}" class="px-6 py-3 bg-indigo-600 text-white rounded-md">Get Started</a>
 </section>
+
+<section class="py-16 bg-white">
+    <div class="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-8 text-center">
+        <div>
+            <h3 class="text-xl font-semibold mb-2">Create</h3>
+            <p class="text-gray-600">Build your own multiple choice questions with an intuitive interface.</p>
+        </div>
+        <div>
+            <h3 class="text-xl font-semibold mb-2">Practice</h3>
+            <p class="text-gray-600">Sharpen your skills by practicing questions across various subjects.</p>
+        </div>
+        <div>
+            <h3 class="text-xl font-semibold mb-2">Share</h3>
+            <p class="text-gray-600">Collaborate with others by sharing your question sets.</p>
+        </div>
+    </div>
+</section>
+
+<section class="py-24 text-center bg-indigo-50">
+    <h2 class="text-3xl font-bold mb-4">Ready to dive in?</h2>
+    <a href="{{ route('register') }}" class="px-6 py-3 bg-indigo-600 text-white rounded-md">Create an Account</a>
+</section>
 @endsection

--- a/resources/views/layouts/frontend.blade.php
+++ b/resources/views/layouts/frontend.blade.php
@@ -19,5 +19,8 @@
     <main>
         @yield('content')
     </main>
+    <footer class="bg-white border-t mt-12 py-6 text-center text-sm text-gray-500">
+        &copy; {{ date('Y') }} MCQ Bank. All rights reserved.
+    </footer>
 </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,6 +16,7 @@ use App\Livewire\Admin\Students\Index as StudentIndex;
 use App\Livewire\Admin\Tags\Index as TagIndex;
 use App\Livewire\Practice;
 Route::view('/', 'frontend.landing')->name('landing');
+Route::view('/frontend', 'frontend.landing');
 
 
 Route::middleware(['auth', 'role:admin'])->group(function () {
@@ -57,3 +58,7 @@ Route::middleware('auth')->group(function () {
 });
 
 include __DIR__.'/auth.php';
+
+Route::fallback(function () {
+    return redirect()->route('landing');
+});


### PR DESCRIPTION
## Summary
- Add `/frontend` route and fallback redirect to landing to avoid 404s
- Expand landing page with feature sections and call to action
- Add footer to frontend layout

## Testing
- `php artisan test` *(fails: require vendor/autoload.php: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a749c737b883269f0dedbe0ba78895