### PR TITLE
Show dashboard link for authenticated users

### DIFF
--- a/resources/views/frontend/landing.blade.php
+++ b/resources/views/frontend/landing.blade.php
@@ -4,7 +4,11 @@
 <section class="py-24 text-center">
     <h1 class="text-5xl font-bold mb-4">Welcome to MCQ Bank</h1>
     <p class="text-lg text-gray-600 mb-8">Practice and create multiple choice questions effortlessly.</p>
-    <a href="{{ route('register') }}" class="px-6 py-3 bg-indigo-600 text-white rounded-md">Get Started</a>
+    @auth
+        <a href="{{ route('admin.dashboard') }}" class="px-6 py-3 bg-indigo-600 text-white rounded-md">Go to Dashboard</a>
+    @else
+        <a href="{{ route('register') }}" class="px-6 py-3 bg-indigo-600 text-white rounded-md">Get Started</a>
+    @endauth
 </section>
 
 <section class="py-16 bg-white">
@@ -26,6 +30,10 @@
 
 <section class="py-24 text-center bg-indigo-50">
     <h2 class="text-3xl font-bold mb-4">Ready to dive in?</h2>
-    <a href="{{ route('register') }}" class="px-6 py-3 bg-indigo-600 text-white rounded-md">Create an Account</a>
+    @auth
+        <a href="{{ route('admin.dashboard') }}" class="px-6 py-3 bg-indigo-600 text-white rounded-md">Go to Dashboard</a>
+    @else
+        <a href="{{ route('register') }}" class="px-6 py-3 bg-indigo-600 text-white rounded-md">Create an Account</a>
+    @endauth
 </section>
 @endsection

--- a/resources/views/layouts/frontend.blade.php
+++ b/resources/views/layouts/frontend.blade.php
@@ -11,8 +11,12 @@
         <div class="max-w-7xl mx-auto px-4 py-6 flex justify-between items-center">
             <a href="/" class="text-xl font-bold">MCQ Bank</a>
             <nav class="space-x-4">
-                <a href="{{ route('login') }}" class="text-sm text-gray-700 hover:text-gray-900">Login</a>
-                <a href="{{ route('register') }}" class="text-sm text-gray-700 hover:text-gray-900">Register</a>
+                @auth
+                    <a href="{{ route('admin.dashboard') }}" class="text-sm text-gray-700 hover:text-gray-900">Dashboard</a>
+                @else
+                    <a href="{{ route('login') }}" class="text-sm text-gray-700 hover:text-gray-900">Login</a>
+                    <a href="{{ route('register') }}" class="text-sm text-gray-700 hover:text-gray-900">Register</a>
+                @endauth
             </nav>
         </div>
     </header>


### PR DESCRIPTION
## Summary
- Hide login and register links on the frontend layout when a user is authenticated and show a dashboard link instead
- Adjust landing page call-to-action to direct authenticated users to the dashboard

## Testing
- `composer test` *(fails: Script @php artisan config:clear --ansi handling the test event returned with error code 255)*
- `composer install` *(fails: curl error 56, GitHub authentication required)*

------
https://chatgpt.com/codex/tasks/task_e_68a74c81b2bc8326a779d009aeaff840