### PR TITLE
Fix sidebar component class binding

### DIFF
--- a/resources/views/livewire/admin/partials/sidebar.blade.php
+++ b/resources/views/livewire/admin/partials/sidebar.blade.php
@@ -35,7 +35,9 @@
                     <x-heroicon-o-question-mark-circle class="w-5 h-5"/>
                     <span class="sidebar-text">Questions</span>
                 </span>
-                <x-heroicon-o-chevron-down class="w-4 h-4 transition-transform" :class="{ 'rotate-180': open }"/>
+                <x-heroicon-o-chevron-down
+                    class="w-4 h-4 transition-transform"
+                    x-bind:class="{ 'rotate-180': open }"/>
             </button>
 
             <div x-show="open" class="space-y-1 pl-8 mt-1" x-cloak>


### PR DESCRIPTION
## Summary
- prevent Blade from treating Alpine class binding as PHP expression

## Testing
- `composer test` *(fails: vendor/autoload.php missing)*
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a75165d8f4832691376615f1d0bbb5