### PR TITLE
Add search and pagination to tag management

### DIFF
--- a/app/Livewire/Admin/Chapters/Index.php
+++ b/app/Livewire/Admin/Chapters/Index.php
@@ -23,6 +23,7 @@ class Index extends Component
 
         $this->dispatch('chapterDeleted');
         session()->flash('success', 'Chapter deleted successfully.');
+        $this->resetPage();
     }
 
     public function render()

--- a/app/Livewire/Admin/Questions/Index.php
+++ b/app/Livewire/Admin/Questions/Index.php
@@ -22,6 +22,7 @@ class Index extends Component
 
         $this->dispatch('questionDeleted');
         session()->flash('success', 'Question deleted successfully.');
+        $this->resetPage();
     }
 
 

--- a/app/Livewire/Admin/Subjects/Index.php
+++ b/app/Livewire/Admin/Subjects/Index.php
@@ -21,6 +21,7 @@ class Index extends Component
 
         $this->dispatch('subjectDeleted');
         session()->flash('success', 'Subject deleted successfully.');
+        $this->resetPage();
     }
 
     public function render()

--- a/resources/views/livewire/admin/tags/index.blade.php
+++ b/resources/views/livewire/admin/tags/index.blade.php
@@ -1,26 +1,46 @@
 <div>
-    <form wire:submit.prevent="save" class="mb-4 flex gap-2">
-        <input type="text" wire:model="name" placeholder="Tag name" class="border p-2 rounded flex-1">
-        <button type="submit" class="bg-green-500 text-white px-4 py-2 rounded">Add</button>
-    </form>
+    <div class="flex justify-between mb-4">
+        <input type="text" wire:model.debounce.300ms="search" placeholder="Search..." class="border p-2 rounded w-1/3">
+        <form wire:submit.prevent="save" class="flex gap-2">
+            <input type="text" wire:model="name" placeholder="Tag name" class="border p-2 rounded">
+            <button type="submit" class="bg-green-500 text-white px-4 py-2 rounded">Add</button>
+        </form>
+    </div>
 
-    <ul class="space-y-2">
-        @foreach($tags as $tag)
-            <li class="flex justify-between items-center border p-2 rounded">
-                @if($editingId === $tag->id)
-                    <form wire:submit.prevent="update" class="flex w-full gap-2">
-                        <input type="text" wire:model="editingName" class="border p-1 rounded flex-1">
-                        <button type="submit" class="bg-blue-500 text-white px-2 py-1 rounded">Save</button>
-                        <button type="button" wire:click="cancelEdit" class="px-2 py-1">Cancel</button>
-                    </form>
-                @else
-                    <span>{{ $tag->name }}</span>
-                    <div class="flex gap-2">
-                        <button wire:click="edit({{ $tag->id }})" class="text-blue-500">Edit</button>
-                        <button wire:click="delete({{ $tag->id }})" class="text-red-500">Delete</button>
-                    </div>
-                @endif
-            </li>
-        @endforeach
-    </ul>
+    <table class="w-full border-collapse border">
+        <thead>
+        <tr class="bg-gray-100">
+            <th class="border p-2">#</th>
+            <th class="border p-2 text-left">Name</th>
+            <th class="border p-2">Actions</th>
+        </tr>
+        </thead>
+        <tbody>
+        @forelse($tags as $tag)
+            <tr>
+                <td class="border p-2">{{ $tag->id }}</td>
+                <td class="border p-2">
+                    @if($editingId === $tag->id)
+                        <form wire:submit.prevent="update" class="flex w-full gap-2">
+                            <input type="text" wire:model="editingName" class="border p-1 rounded flex-1">
+                            <button type="submit" class="bg-blue-500 text-white px-2 py-1 rounded">Save</button>
+                            <button type="button" wire:click="cancelEdit" class="px-2 py-1">Cancel</button>
+                        </form>
+                    @else
+                        {{ $tag->name }}
+                    @endif
+                </td>
+                <td class="border p-2 space-x-2">
+                    @if($editingId !== $tag->id)
+                        <button wire:click="edit({{ $tag->id }})" class="text-blue-600 underline">Edit</button>
+                        <button wire:click="delete({{ $tag->id }})" onclick="return confirm('Delete this tag?')" class="text-red-600 underline">Delete</button>
+                    @endif
+                </td>
+            </tr>
+        @empty
+            <tr><td colspan="3" class="p-4 text-center text-gray-500">No tags found.</td></tr>
+        @endforelse
+        </tbody>
+    </table>
+    <div class="mt-4">{{ $tags->links() }}</div>
 </div>


### PR DESCRIPTION
## Summary
- Add Livewire pagination and search to tag management table
- Reset pagination after deletions for questions, subjects, and chapters to keep tables in sync

## Testing
- `npm test` (fails: Missing script)
- `php artisan test` (fails: vendor/autoload.php missing)

------
https://chatgpt.com/codex/tasks/task_e_68a7885d7dfc83268c238e872dc76da7