### PR TITLE
Refine question creation form

### DIFF
--- a/app/Livewire/Admin/Questions/Create.php
+++ b/app/Livewire/Admin/Questions/Create.php
@@ -15,6 +15,11 @@ class Create extends Component
         ['option_text' => '', 'is_correct' => false],
     ];
 
+    public function updatedSubjectId()
+    {
+        $this->chapter_id = null;
+    }
+
     public function save()
     {
         $this->validate([

--- a/resources/views/livewire/admin/questions/create.blade.php
+++ b/resources/views/livewire/admin/questions/create.blade.php
@@ -1,25 +1,27 @@
 <div x-data class="max-w-4xl mx-auto p-6 bg-white dark:bg-gray-800 rounded-lg shadow">
     <form wire:submit.prevent="save" class="space-y-6">
-        {{-- Subject --}}
-        <div>
-            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Subject</label>
-            <select wire:model="subject_id" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
-                <option value="">-- Select --</option>
-                @foreach($subjects as $s)
-                    <option value="{{ $s->id }}">{{ $s->name }}</option>
-                @endforeach
-            </select>
-        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {{-- Subject --}}
+            <div>
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Subject</label>
+                <select wire:model="subject_id" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
+                    <option value="">-- Select --</option>
+                    @foreach($subjects as $s)
+                        <option value="{{ $s->id }}">{{ $s->name }}</option>
+                    @endforeach
+                </select>
+            </div>
 
-        {{-- Chapter --}}
-        <div>
-            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Chapter</label>
-            <select wire:model="chapter_id" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
-                <option value="">-- Select --</option>
-                @foreach($chapters as $c)
-                    <option value="{{ $c->id }}">{{ $c->name }}</option>
-                @endforeach
-            </select>
+            {{-- Chapter --}}
+            <div>
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Chapter</label>
+                <select wire:model="chapter_id" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
+                    <option value="">-- Select --</option>
+                    @foreach($chapters as $c)
+                        <option value="{{ $c->id }}">{{ $c->name }}</option>
+                    @endforeach
+                </select>
+            </div>
         </div>
 
         {{-- Main Question --}}
@@ -77,11 +79,16 @@
         let quillEditors = {};
 
         function initEditors() {
-            window.quillEditors = {};
+            const main = document.getElementById('editor');
+            if (!main || main.classList.contains('ql-container')) return;
+
+            quillEditors = {};
+            window.quillEditors = quillEditors;
+
             const toolbarOptions = [
                 ['bold', 'italic'],
                 [{ 'script': 'sub' }, { 'script': 'super' }],
-                ['customMath'], // আমাদের কাস্টম popup button
+                ['customMath'],
                 ['clean']
             ];
 
@@ -109,6 +116,7 @@
 
             // --- Options Editors ---
             document.querySelectorAll('[id^="opt_editor_"]').forEach(el => {
+                if (el.classList.contains('ql-container')) return;
                 let index = el.id.replace('opt_editor_', '');
                 let optEditor = new Quill(`#${el.id}`, {
                     theme: 'snow',
@@ -149,11 +157,7 @@
             @this.set('tagIds', window.tsTags.items);
         }
 
-        if (document.readyState !== 'loading') {
-            initEditors();
-        } else {
-            document.addEventListener('DOMContentLoaded', initEditors);
-        }
+        document.addEventListener('livewire:load', initEditors);
         document.addEventListener('livewire:navigated', initEditors);
     </script>
 @endpush


### PR DESCRIPTION
## Summary
- Reset chapter selection when the subject changes
- Lay out subject and chapter fields in a responsive grid
- Guard Quill initialization to prevent duplicate toolbars

## Testing
- `php artisan test` *(fails: requires GitHub credentials for composer dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a78eeeb7c88326bbdb93834e07b08a