### PR TITLE
Integrate TomSelect for dependent subject and chapter selects

### DIFF
--- a/app/Livewire/Admin/Questions/Create.php
+++ b/app/Livewire/Admin/Questions/Create.php
@@ -15,9 +15,14 @@ class Create extends Component
         ['option_text' => '', 'is_correct' => false],
     ];
 
-    public function updatedSubjectId()
+    public function updatedSubjectId($value)
     {
         $this->chapter_id = null;
+        $chapters = Chapter::where('subject_id', $value)
+            ->get()
+            ->map(fn($c) => ['value' => $c->id, 'text' => $c->name])
+            ->all();
+        $this->dispatch('chaptersUpdated', chapters: $chapters);
     }
 
     public function save()

--- a/app/Livewire/Admin/Questions/Edit.php
+++ b/app/Livewire/Admin/Questions/Edit.php
@@ -54,6 +54,16 @@ class Edit extends Component
         return redirect('/admin/questions')->with('success', 'Question updated.');
     }
 
+    public function updatedSubjectId($value)
+    {
+        $this->chapter_id = null;
+        $chapters = Chapter::where('subject_id', $value)
+            ->get()
+            ->map(fn($c) => ['value' => $c->id, 'text' => $c->name])
+            ->all();
+        $this->dispatch('chaptersUpdated', chapters: $chapters);
+    }
+
     public function render()
     {
         return view('livewire.admin.questions.edit', [

--- a/resources/views/livewire/admin/questions/create.blade.php
+++ b/resources/views/livewire/admin/questions/create.blade.php
@@ -2,23 +2,23 @@
     <form wire:submit.prevent="save" class="space-y-6">
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             {{-- Subject --}}
-            <div>
+            <div wire:ignore>
                 <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Subject</label>
-                <select wire:model="subject_id" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
+                <select id="subject" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
                     <option value="">-- Select --</option>
                     @foreach($subjects as $s)
-                        <option value="{{ $s->id }}">{{ $s->name }}</option>
+                        <option value="{{ $s->id }}" @selected($s->id == $subject_id)>{{ $s->name }}</option>
                     @endforeach
                 </select>
             </div>
 
             {{-- Chapter --}}
-            <div>
+            <div wire:ignore>
                 <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Chapter</label>
-                <select wire:model="chapter_id" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
+                <select id="chapter" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
                     <option value="">-- Select --</option>
                     @foreach($chapters as $c)
-                        <option value="{{ $c->id }}">{{ $c->name }}</option>
+                        <option value="{{ $c->id }}" @selected($c->id == $chapter_id)>{{ $c->name }}</option>
                     @endforeach
                 </select>
             </div>
@@ -77,6 +77,7 @@
     <script src="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/js/tom-select.complete.min.js"></script>
     <script>
         let quillEditors = {};
+        let tsSubject, tsChapter;
 
         function initEditors() {
             const main = document.getElementById('editor');
@@ -145,6 +146,22 @@
                 btn.innerHTML = '∑';
             });
 
+            if (tsSubject) tsSubject.destroy();
+            tsSubject = new TomSelect('#subject', {
+                onChange: (value) => {
+                    @this.set('subject_id', value);
+                }
+            });
+            tsSubject.setValue(@json($subject_id));
+
+            if (tsChapter) tsChapter.destroy();
+            tsChapter = new TomSelect('#chapter', {
+                onChange: (value) => {
+                    @this.set('chapter_id', value);
+                }
+            });
+            tsChapter.setValue(@json($chapter_id));
+
             if (window.tsTags) window.tsTags.destroy();
             window.tsTags = new TomSelect('#tags', {
                 plugins: ['remove_button'],
@@ -156,6 +173,14 @@
             });
             @this.set('tagIds', window.tsTags.items);
         }
+
+        window.addEventListener('chaptersUpdated', e => {
+            if (!tsChapter) return;
+            tsChapter.clearOptions();
+            tsChapter.addOptions(e.detail.chapters);
+            tsChapter.refreshOptions(false);
+            tsChapter.setValue('');
+        });
 
         document.addEventListener('livewire:load', initEditors);
         document.addEventListener('livewire:navigated', initEditors);

--- a/resources/views/livewire/admin/questions/edit.blade.php
+++ b/resources/views/livewire/admin/questions/edit.blade.php
@@ -1,23 +1,23 @@
 <div x-data>
     <form wire:submit.prevent="save" class="space-y-4">
         {{-- Subject --}}
-        <div>
+        <div wire:ignore>
             <label>Subject</label>
-            <select wire:model="subject_id" class="border p-2 rounded w-full">
+            <select id="subject" class="border p-2 rounded w-full">
                 <option value="">-- Select --</option>
                 @foreach($subjects as $s)
-                    <option value="{{ $s->id }}">{{ $s->name }}</option>
+                    <option value="{{ $s->id }}" @selected($s->id == $subject_id)>{{ $s->name }}</option>
                 @endforeach
             </select>
         </div>
 
         {{-- Chapter --}}
-        <div>
+        <div wire:ignore>
             <label>Chapter</label>
-            <select wire:model="chapter_id" class="border p-2 rounded w-full">
+            <select id="chapter" class="border p-2 rounded w-full">
                 <option value="">-- Select --</option>
                 @foreach($chapters as $c)
-                    <option value="{{ $c->id }}">{{ $c->name }}</option>
+                    <option value="{{ $c->id }}" @selected($c->id == $chapter_id)>{{ $c->name }}</option>
                 @endforeach
             </select>
         </div>
@@ -81,6 +81,7 @@
     <script src="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/js/tom-select.complete.min.js"></script>
     <script>
         let quillEditors = {};
+        let tsSubject, tsChapter;
 
         function initEditors() {
             window.quillEditors = {};
@@ -141,6 +142,22 @@
                 btn.innerHTML = '∑';
             });
 
+            if (tsSubject) tsSubject.destroy();
+            tsSubject = new TomSelect('#subject', {
+                onChange: (value) => {
+                    @this.set('subject_id', value);
+                }
+            });
+            tsSubject.setValue(@json($subject_id));
+
+            if (tsChapter) tsChapter.destroy();
+            tsChapter = new TomSelect('#chapter', {
+                onChange: (value) => {
+                    @this.set('chapter_id', value);
+                }
+            });
+            tsChapter.setValue(@json($chapter_id));
+
             if (window.tsTags) window.tsTags.destroy();
             window.tsTags = new TomSelect('#tags', {
                 plugins: ['remove_button'],
@@ -152,6 +169,14 @@
             });
             @this.set('tagIds', window.tsTags.items);
         }
+
+        window.addEventListener('chaptersUpdated', e => {
+            if (!tsChapter) return;
+            tsChapter.clearOptions();
+            tsChapter.addOptions(e.detail.chapters);
+            tsChapter.refreshOptions(false);
+            tsChapter.setValue('');
+        });
 
         if (document.readyState !== 'loading') {
             initEditors();


### PR DESCRIPTION
## Summary
- Enhance question creation and editing forms with TomSelect-powered subject and chapter dropdowns
- Dispatch Livewire events to update chapter options dynamically when subject changes

## Testing
- `composer test` *(fails: vendor autoload missing)*
- `composer install` *(fails: missing GitHub token; cannot download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a79540cf8c832681565589479bf30c