### PR TITLE
Fix question deletion and improve search filtering

### DIFF
--- a/resources/views/livewire/admin/questions/index.blade.php
+++ b/resources/views/livewire/admin/questions/index.blade.php
@@ -1,6 +1,6 @@
 <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4">
-        <input type="text" wire:model.debounce.300ms="search" placeholder="Search questions..."
+        <input type="text" wire:model.live.debounce.300ms="search" placeholder="Search questions..."
                class="flex-1 px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
         <a wire:navigate href="{{ route('admin.questions.create') }}"
            class="inline-flex items-center justify-center px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500">
@@ -29,7 +29,7 @@
                     <td class="px-4 py-2 space-x-2">
                         <a wire:navigate href="{{ route('admin.questions.edit', $q) }}"
                            class="text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300">Edit</a>
-                        <button wire:click="delete({{ $q->id }})"
+                        <button wire:click.prevent="deleteQuestion({{ $q->id }})"
                                 onclick="return confirm('Delete this question?')"
                                 class="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300">Delete</button>
                     </td>


### PR DESCRIPTION
## Summary
- Ensure questions are fully removed along with related options and tags
- Refactor search to match subject and chapter names and add live input binding
- Prevent default action when deleting from the question list

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a79da325b4832695a6f1585493f8d4