### PR TITLE
Add delete question action to question index

### DIFF
--- a/app/Livewire/Admin/Questions/Index.php
+++ b/app/Livewire/Admin/Questions/Index.php
@@ -19,15 +19,18 @@ class Index extends Component
         $this->resetPage();
     }
 
-    public function deleteQuestion($id)
+    /**
+     * Permanently delete a question along with its relations.
+     */
+    public function deleteQuestion(int $id): void
     {
-        $question = Question::with('tags')->findOrFail($id);
+        // Load the question with its related tags and options
+        $question = Question::with(['tags', 'options'])->findOrFail($id);
 
-        // remove related data first
+        // Remove related records before forcing the delete
         $question->tags()->detach();
         $question->options()->delete();
 
-        // force delete to remove the soft deleted record completely
         $question->forceDelete();
 
         $this->dispatch('questionDeleted');

--- a/resources/views/livewire/admin/questions/index.blade.php
+++ b/resources/views/livewire/admin/questions/index.blade.php
@@ -29,7 +29,7 @@
                     <td class="px-4 py-2 space-x-2">
                         <a wire:navigate href="{{ route('admin.questions.edit', $q) }}"
                            class="text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300">Edit</a>
-                        <button wire:click.prevent="deleteQuestion({{ $q->id }})"
+                        <button type="button" wire:click="deleteQuestion({{ $q->id }})"
                                 onclick="return confirm('Delete this question?')"
                                 class="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300">Delete</button>
                     </td>


### PR DESCRIPTION
## Summary
- implement `deleteQuestion` method for admin question listing with typed parameters and relation clean-up
- ensure delete button triggers the new action correctly

## Testing
- `composer test` *(fails: Script @php artisan config:clear --ansi handling the test event returned with error code 255)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a114833c8326b068026f2dc1e715