### PR TITLE
Fix chapter selection reset on edit

### DIFF
--- a/resources/views/livewire/admin/questions/create.blade.php
+++ b/resources/views/livewire/admin/questions/create.blade.php
@@ -151,7 +151,7 @@
                     @this.set('subject_id', value);
                 }
             });
-            tsSubject.setValue(@json($subject_id));
+            tsSubject.setValue(@json($subject_id), true);
 
             if (tsChapter) tsChapter.destroy();
             tsChapter = new TomSelect('#chapter', {
@@ -159,7 +159,7 @@
                     @this.set('chapter_id', value);
                 }
             });
-            tsChapter.setValue(@json($chapter_id));
+            tsChapter.setValue(@json($chapter_id), true);
 
             if (window.tsTags) window.tsTags.destroy();
             window.tsTags = new TomSelect('#tags', {

--- a/resources/views/livewire/admin/questions/edit.blade.php
+++ b/resources/views/livewire/admin/questions/edit.blade.php
@@ -151,7 +151,7 @@
                     @this.set('subject_id', value);
                 }
             });
-            tsSubject.setValue(@json($subject_id));
+            tsSubject.setValue(@json($subject_id), true);
 
             if (tsChapter) tsChapter.destroy();
             tsChapter = new TomSelect('#chapter', {
@@ -159,7 +159,7 @@
                     @this.set('chapter_id', value);
                 }
             });
-            tsChapter.setValue(@json($chapter_id));
+            tsChapter.setValue(@json($chapter_id), true);
 
             if (window.tsTags) window.tsTags.destroy();
             window.tsTags = new TomSelect('#tags', {


### PR DESCRIPTION
## Summary
- ensure TomSelect doesn't clear chapter when editing question
- update create/edit question forms to set selects without triggering change

## Testing
- `composer test` *(fails: require(/workspace/laravel-livewire-question-bank-project/vendor/autoload.php): Failed to open stream: No such file or directory)*
- `composer install` *(fails: curl error 56 while downloading from GitHub, requires authentication token)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a9ee17348326b9465e7a219c2916