### PR TITLE
Add subject & chapter filters with SweetAlert delete confirm

### DIFF
--- a/resources/views/livewire/admin/questions.blade.php
+++ b/resources/views/livewire/admin/questions.blade.php
@@ -1,7 +1,23 @@
 <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4">
-        <input type="text" wire:model.live.debounce.300ms="search" placeholder="Search questions..."
-               class="flex-1 px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
+        <div class="flex flex-col sm:flex-row gap-4 flex-1">
+            <input type="text" wire:model.live.debounce.300ms="search" placeholder="Search questions..."
+                   class="flex-1 px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
+            <select wire:model.live="subjectId"
+                    class="px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200">
+                <option value="">All Subjects</option>
+                @foreach($subjects as $sub)
+                    <option value="{{ $sub->id }}">{{ $sub->name }}</option>
+                @endforeach
+            </select>
+            <select wire:model.live="chapterId"
+                    class="px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200">
+                <option value="">All Chapters</option>
+                @foreach($chapters as $ch)
+                    <option value="{{ $ch->id }}">{{ $ch->name }}</option>
+                @endforeach
+            </select>
+        </div>
         <a wire:navigate href="{{ route('admin.questions.create') }}"
            class="inline-flex items-center justify-center px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500">
             + New Question
@@ -29,8 +45,7 @@
                     <td class="px-4 py-2 space-x-2">
                         <a wire:navigate href="{{ route('admin.questions.edit', $q) }}"
                            class="text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300">Edit</a>
-                        <button type="button" wire:click="deleteQuestion({{ $q->id }})"
-                                onclick="confirm('Delete this question?') || event.stopImmediatePropagation()"
+                        <button type="button" onclick="confirmDelete({{ $q->id }})"
                                 class="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300">Delete</button>
                     </td>
                 </tr>
@@ -56,6 +71,22 @@
                 position: 'top-end',
                 showConfirmButton: false,
                 timer: 1500,
+            });
+        }
+
+        function confirmDelete(id) {
+            if (!window.Swal) return;
+            Swal.fire({
+                title: 'Delete this question?',
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonColor: '#d33',
+                cancelButtonColor: '#3085d6',
+                confirmButtonText: 'Yes, delete it!'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    Livewire.dispatch('deleteQuestionConfirmed', { id: id });
+                }
             });
         }
 


### PR DESCRIPTION
## Summary
- allow filtering questions by subject and chapter
- add SweetAlert confirmation dialog when deleting a question

## Testing
- `php artisan test` *(fails: require(/workspace/laravel-livewire-question-bank-project/vendor/autoload.php): No such file or directory)*
- `composer install` *(fails: Failed to download packages: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c5fd1e2c8326b7f3e852a1c09564