### PR TITLE
Improve admin tag, chapter, and subject management

### DIFF
--- a/app/Livewire/Admin/Chapters/Index.php
+++ b/app/Livewire/Admin/Chapters/Index.php
@@ -14,16 +14,27 @@ class Index extends Component
     public $search = '';
     public $subjectId = '';
 
-    protected $listeners = ['chapterDeleted' => '$refresh'];
+    protected $listeners = [
+        'chapterDeleted' => '$refresh',
+        'deleteChapterConfirmed' => 'delete',
+    ];
+
+    public function updatingSearch(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatingSubjectId(): void
+    {
+        $this->resetPage();
+    }
 
     public function delete($id)
     {
-        $chapter = Chapter::findOrFail($id);
-        $chapter->delete();
+        Chapter::findOrFail($id)->delete();
 
-        $this->dispatch('chapterDeleted');
-        session()->flash('success', 'Chapter deleted successfully.');
         $this->resetPage();
+        $this->dispatch('chapterDeleted', message: 'Chapter deleted successfully.');
     }
 
     public function render()

--- a/app/Livewire/Admin/Subjects/Index.php
+++ b/app/Livewire/Admin/Subjects/Index.php
@@ -12,16 +12,22 @@ class Index extends Component
 
     public $search = '';
 
-    protected $listeners = ['subjectDeleted' => '$refresh'];
+    protected $listeners = [
+        'subjectDeleted' => '$refresh',
+        'deleteSubjectConfirmed' => 'delete',
+    ];
+
+    public function updatingSearch(): void
+    {
+        $this->resetPage();
+    }
 
     public function delete($id)
     {
-        $subject = Subject::findOrFail($id);
-        $subject->delete();
+        Subject::findOrFail($id)->delete();
 
-        $this->dispatch('subjectDeleted');
-        session()->flash('success', 'Subject deleted successfully.');
         $this->resetPage();
+        $this->dispatch('subjectDeleted', message: 'Subject deleted successfully.');
     }
 
     public function render()

--- a/app/Livewire/Admin/Tags/Index.php
+++ b/app/Livewire/Admin/Tags/Index.php
@@ -15,7 +15,15 @@ class Index extends Component
     public $editingName = '';
     public $search = '';
 
-    protected $listeners = ['tagDeleted' => '$refresh'];
+    protected $listeners = [
+        'tagDeleted' => '$refresh',
+        'deleteTagConfirmed' => 'delete',
+    ];
+
+    public function updatingSearch(): void
+    {
+        $this->resetPage();
+    }
 
     public function save()
     {
@@ -29,15 +37,15 @@ class Index extends Component
 
         $this->name = '';
         $this->resetPage();
+        $this->dispatch('tagSaved', message: 'Tag added successfully.');
     }
 
     public function delete($id)
     {
         Tag::findOrFail($id)->delete();
 
-        $this->dispatch('tagDeleted');
-        session()->flash('success', 'Tag deleted successfully.');
         $this->resetPage();
+        $this->dispatch('tagDeleted', message: 'Tag deleted successfully.');
     }
 
     public function edit($id)
@@ -57,6 +65,7 @@ class Index extends Component
 
         $this->editingId = null;
         $this->editingName = '';
+        $this->dispatch('tagUpdated', message: 'Tag updated successfully.');
     }
 
     public function cancelEdit()

--- a/resources/views/livewire/admin/chapters/index.blade.php
+++ b/resources/views/livewire/admin/chapters/index.blade.php
@@ -1,41 +1,102 @@
-<div>
-    <div class="flex justify-between mb-4">
-        <div class="flex gap-2 w-2/3">
-            <input type="text" wire:model.debounce.300ms="search" placeholder="Search..." class="border p-2 rounded flex-1">
-            <select wire:model="subjectId" class="border p-2 rounded">
+<div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4">
+        <div class="flex flex-col sm:flex-row gap-4 flex-1">
+            <input type="text"
+                   wire:model.live.debounce.300ms="search"
+                   placeholder="Search chapters..."
+                   class="flex-1 px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
+            <select wire:model.live="subjectId"
+                    class="px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200">
                 <option value="">All Subjects</option>
                 @foreach($subjects as $sub)
                     <option value="{{ $sub->id }}">{{ $sub->name }}</option>
                 @endforeach
             </select>
         </div>
-        <a wire:navigate href="{{ route('admin.chapters.create') }}" class="bg-blue-500 text-white px-4 py-2 rounded">+ New Chapter</a>
+        <a wire:navigate href="{{ route('admin.chapters.create') }}"
+           class="inline-flex items-center justify-center px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+            + New Chapter
+        </a>
     </div>
 
-    <table class="w-full border-collapse border">
-        <thead>
-        <tr class="bg-gray-100">
-            <th class="border p-2">#</th>
-            <th class="border p-2 text-left">Name</th>
-            <th class="border p-2">Subject</th>
-            <th class="border p-2">Actions</th>
-        </tr>
-        </thead>
-        <tbody>
-        @forelse($chapters as $chapter)
+    <div class="overflow-x-auto">
+        <table class="min-w-full text-sm divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-700">
             <tr>
-                <td class="border p-2">{{ $chapter->id }}</td>
-                <td class="border p-2">{{ $chapter->name }}</td>
-                <td class="border p-2">{{ $chapter->subject->name }}</td>
-                <td class="border p-2 space-x-2">
-                    <a wire:navigate href="{{ route('admin.chapters.edit', $chapter) }}" class="text-blue-600 underline">Edit</a>
-                    <button wire:click="delete({{ $chapter->id }})" onclick="return confirm('Delete this chapter?')" class="text-red-600 underline">Delete</button>
-                </td>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">#</th>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Name</th>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Subject</th>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Actions</th>
             </tr>
-        @empty
-            <tr><td colspan="4" class="p-4 text-center text-gray-500">No chapters found.</td></tr>
-        @endforelse
-        </tbody>
-    </table>
+            </thead>
+            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+            @forelse($chapters as $chapter)
+                <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+                    <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $chapter->id }}</td>
+                    <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $chapter->name }}</td>
+                    <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $chapter->subject->name }}</td>
+                    <td class="px-4 py-2 space-x-2">
+                        <a wire:navigate href="{{ route('admin.chapters.edit', $chapter) }}"
+                           class="text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300">Edit</a>
+                        <button type="button" onclick="confirmDelete({{ $chapter->id }})"
+                                class="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300">Delete</button>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="4" class="px-4 py-6 text-center text-gray-500 dark:text-gray-400">No chapters found.</td>
+                </tr>
+            @endforelse
+            </tbody>
+        </table>
+    </div>
     <div class="mt-4">{{ $chapters->links() }}</div>
 </div>
+
+@push('scripts')
+<script>
+    function showToast(message) {
+        if (!window.Swal) return;
+        Swal.fire({
+            toast: true,
+            icon: 'success',
+            title: message,
+            position: 'top-end',
+            showConfirmButton: false,
+            timer: 1500,
+        });
+    }
+
+    function confirmDelete(id) {
+        if (!window.Swal) return;
+        Swal.fire({
+            title: 'Delete this chapter?',
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonColor: '#d33',
+            cancelButtonColor: '#3085d6',
+            confirmButtonText: 'Yes, delete it!'
+        }).then((result) => {
+            if (result.isConfirmed) {
+                Livewire.dispatch('deleteChapterConfirmed', { id: id });
+            }
+        });
+    }
+
+    window.sessionSuccess = @json(session('success'));
+
+    function handleSessionToast() {
+        if (window.sessionSuccess) {
+            showToast(window.sessionSuccess);
+            window.sessionSuccess = null;
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', handleSessionToast);
+    document.addEventListener('livewire:navigated', handleSessionToast);
+
+    window.addEventListener('chapterDeleted', e => {
+        showToast(e.detail.message || 'Chapter deleted successfully.');
+    });
+</script>
+@endpush

--- a/resources/views/livewire/admin/subjects/index.blade.php
+++ b/resources/views/livewire/admin/subjects/index.blade.php
@@ -1,31 +1,91 @@
-<div>
-    <div class="flex justify-between mb-4">
-        <input type="text" wire:model.debounce.300ms="search" placeholder="Search..." class="border p-2 rounded w-1/3">
-        <a wire:navigate href="{{ route('admin.subjects.create') }}" class="bg-blue-500 text-white px-4 py-2 rounded">+ New Subject</a>
+<div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4">
+        <input type="text"
+               wire:model.live.debounce.300ms="search"
+               placeholder="Search subjects..."
+               class="flex-1 px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
+        <a wire:navigate href="{{ route('admin.subjects.create') }}"
+           class="inline-flex items-center justify-center px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+            + New Subject
+        </a>
     </div>
 
-    <table class="w-full border-collapse border">
-        <thead>
-        <tr class="bg-gray-100">
-            <th class="border p-2">#</th>
-            <th class="border p-2 text-left">Name</th>
-            <th class="border p-2">Actions</th>
-        </tr>
-        </thead>
-        <tbody>
-        @forelse($subjects as $subject)
+    <div class="overflow-x-auto">
+        <table class="min-w-full text-sm divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-700">
             <tr>
-                <td class="border p-2">{{ $subject->id }}</td>
-                <td class="border p-2">{{ $subject->name }}</td>
-                <td class="border p-2 space-x-2">
-                    <a wire:navigate href="{{ route('admin.subjects.edit', $subject) }}" class="text-blue-600 underline">Edit</a>
-                    <button wire:click="delete({{ $subject->id }})" onclick="return confirm('Delete this subject?')" class="text-red-600 underline">Delete</button>
-                </td>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">#</th>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Name</th>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Actions</th>
             </tr>
-        @empty
-            <tr><td colspan="3" class="p-4 text-center text-gray-500">No subjects found.</td></tr>
-        @endforelse
-        </tbody>
-    </table>
+            </thead>
+            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+            @forelse($subjects as $subject)
+                <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+                    <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $subject->id }}</td>
+                    <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $subject->name }}</td>
+                    <td class="px-4 py-2 space-x-2">
+                        <a wire:navigate href="{{ route('admin.subjects.edit', $subject) }}"
+                           class="text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300">Edit</a>
+                        <button type="button" onclick="confirmDelete({{ $subject->id }})"
+                                class="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300">Delete</button>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="3" class="px-4 py-6 text-center text-gray-500 dark:text-gray-400">No subjects found.</td>
+                </tr>
+            @endforelse
+            </tbody>
+        </table>
+    </div>
     <div class="mt-4">{{ $subjects->links() }}</div>
 </div>
+
+@push('scripts')
+<script>
+    function showToast(message) {
+        if (!window.Swal) return;
+        Swal.fire({
+            toast: true,
+            icon: 'success',
+            title: message,
+            position: 'top-end',
+            showConfirmButton: false,
+            timer: 1500,
+        });
+    }
+
+    function confirmDelete(id) {
+        if (!window.Swal) return;
+        Swal.fire({
+            title: 'Delete this subject?',
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonColor: '#d33',
+            cancelButtonColor: '#3085d6',
+            confirmButtonText: 'Yes, delete it!'
+        }).then((result) => {
+            if (result.isConfirmed) {
+                Livewire.dispatch('deleteSubjectConfirmed', { id: id });
+            }
+        });
+    }
+
+    window.sessionSuccess = @json(session('success'));
+
+    function handleSessionToast() {
+        if (window.sessionSuccess) {
+            showToast(window.sessionSuccess);
+            window.sessionSuccess = null;
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', handleSessionToast);
+    document.addEventListener('livewire:navigated', handleSessionToast);
+
+    window.addEventListener('subjectDeleted', e => {
+        showToast(e.detail.message || 'Subject deleted successfully.');
+    });
+</script>
+@endpush

--- a/resources/views/livewire/admin/tags/index.blade.php
+++ b/resources/views/livewire/admin/tags/index.blade.php
@@ -1,46 +1,113 @@
-<div>
-    <div class="flex justify-between mb-4">
-        <input type="text" wire:model.debounce.300ms="search" placeholder="Search..." class="border p-2 rounded w-1/3">
+<div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+    <div class="flex flex-col sm:flex-row sm:justify-between gap-4 mb-4">
+        <input type="text" wire:model.live.debounce.300ms="search" placeholder="Search tags..."
+               class="flex-1 px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
         <form wire:submit.prevent="save" class="flex gap-2">
-            <input type="text" wire:model="name" placeholder="Tag name" class="border p-2 rounded">
-            <button type="submit" class="bg-green-500 text-white px-4 py-2 rounded">Add</button>
+            <input type="text" wire:model="name" placeholder="Tag name"
+                   class="px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
+            <button type="submit"
+                    class="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500">Add</button>
         </form>
     </div>
 
-    <table class="w-full border-collapse border">
-        <thead>
-        <tr class="bg-gray-100">
-            <th class="border p-2">#</th>
-            <th class="border p-2 text-left">Name</th>
-            <th class="border p-2">Actions</th>
-        </tr>
-        </thead>
-        <tbody>
-        @forelse($tags as $tag)
+    <div class="overflow-x-auto">
+        <table class="min-w-full text-sm divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-700">
             <tr>
-                <td class="border p-2">{{ $tag->id }}</td>
-                <td class="border p-2">
-                    @if($editingId === $tag->id)
-                        <form wire:submit.prevent="update" class="flex w-full gap-2">
-                            <input type="text" wire:model="editingName" class="border p-1 rounded flex-1">
-                            <button type="submit" class="bg-blue-500 text-white px-2 py-1 rounded">Save</button>
-                            <button type="button" wire:click="cancelEdit" class="px-2 py-1">Cancel</button>
-                        </form>
-                    @else
-                        {{ $tag->name }}
-                    @endif
-                </td>
-                <td class="border p-2 space-x-2">
-                    @if($editingId !== $tag->id)
-                        <button wire:click="edit({{ $tag->id }})" class="text-blue-600 underline">Edit</button>
-                        <button wire:click="delete({{ $tag->id }})" onclick="return confirm('Delete this tag?')" class="text-red-600 underline">Delete</button>
-                    @endif
-                </td>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">#</th>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Name</th>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Actions</th>
             </tr>
-        @empty
-            <tr><td colspan="3" class="p-4 text-center text-gray-500">No tags found.</td></tr>
-        @endforelse
-        </tbody>
-    </table>
+            </thead>
+            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+            @forelse($tags as $tag)
+                <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+                    <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $tag->id }}</td>
+                    <td class="px-4 py-2">
+                        @if($editingId === $tag->id)
+                            <form wire:submit.prevent="update" class="flex w-full gap-2">
+                                <input type="text" wire:model="editingName"
+                                       class="flex-1 px-2 py-1 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
+                                <button type="submit" class="px-3 py-1 bg-indigo-600 text-white rounded-md hover:bg-indigo-700">Save</button>
+                                <button type="button" wire:click="cancelEdit"
+                                        class="px-3 py-1 bg-gray-200 rounded-md hover:bg-gray-300 dark:bg-gray-600 dark:hover:bg-gray-500 dark:text-gray-200">Cancel</button>
+                            </form>
+                        @else
+                            <span class="text-gray-700 dark:text-gray-300">{{ $tag->name }}</span>
+                        @endif
+                    </td>
+                    <td class="px-4 py-2 space-x-2">
+                        @if($editingId !== $tag->id)
+                            <button wire:click="edit({{ $tag->id }})"
+                                    class="text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300">Edit</button>
+                            <button type="button" onclick="confirmDelete({{ $tag->id }})"
+                                    class="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300">Delete</button>
+                        @endif
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="3" class="px-4 py-6 text-center text-gray-500 dark:text-gray-400">No tags found.</td>
+                </tr>
+            @endforelse
+            </tbody>
+        </table>
+    </div>
     <div class="mt-4">{{ $tags->links() }}</div>
 </div>
+
+@push('scripts')
+<script>
+    function showToast(message) {
+        if (!window.Swal) return;
+        Swal.fire({
+            toast: true,
+            icon: 'success',
+            title: message,
+            position: 'top-end',
+            showConfirmButton: false,
+            timer: 1500,
+        });
+    }
+
+    function confirmDelete(id) {
+        if (!window.Swal) return;
+        Swal.fire({
+            title: 'Delete this tag?',
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonColor: '#d33',
+            cancelButtonColor: '#3085d6',
+            confirmButtonText: 'Yes, delete it!'
+        }).then((result) => {
+            if (result.isConfirmed) {
+                Livewire.dispatch('deleteTagConfirmed', { id: id });
+            }
+        });
+    }
+
+    window.sessionSuccess = @json(session('success'));
+
+    function handleSessionToast() {
+        if (window.sessionSuccess) {
+            showToast(window.sessionSuccess);
+            window.sessionSuccess = null;
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', handleSessionToast);
+    document.addEventListener('livewire:navigated', handleSessionToast);
+
+    window.addEventListener('tagSaved', e => {
+        showToast(e.detail.message || 'Tag added successfully.');
+    });
+
+    window.addEventListener('tagUpdated', e => {
+        showToast(e.detail.message || 'Tag updated successfully.');
+    });
+
+    window.addEventListener('tagDeleted', e => {
+        showToast(e.detail.message || 'Tag deleted successfully.');
+    });
+</script>
+@endpush


### PR DESCRIPTION
## Summary
- Restyle admin subject, chapter, and tag listings with modern table layout
- Enable pagination reset and sweetalert toast events for CRUD actions
- Add confirm dialogs and success toasts for deleting, updating, and creating tags

## Testing
- `phpunit` *(fails: command not found)*
- `composer install` *(fails: GitHub API rate limit 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a7cf721a908326a2ed2a6da366ac38