### PR TITLE
Fix header logout and dynamic avatar

### DIFF
--- a/resources/views/livewire/admin/partials/header.blade.php
+++ b/resources/views/livewire/admin/partials/header.blade.php
@@ -13,13 +13,16 @@
         </div>
         <div class="relative">
             <button id="userMenuButton" class="flex items-center gap-2">
-                <img class="h-9 w-9 rounded-full object-cover" src="https://ui-avatars.com/api/?name=Admin+User&background=random" alt="Admin">
+                <img class="h-9 w-9 rounded-full object-cover" src="{{ auth()->user()->avatar_url }}" alt="{{ auth()->user()->name }}">
             </button>
             <div id="userMenu" class="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-700 rounded-lg shadow-xl py-1 z-10 hidden">
                 <a href="{{ route('profile') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600">Profile</a>
                 <a href="{{ route('admin.settings') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600">Settings</a>
                 <hr class="border-gray-200 dark:border-gray-600 my-1">
-                <a href="#" class="block px-4 py-2 text-sm text-red-500 hover:bg-gray-100 dark:hover:bg-gray-600">Logout</a>
+                <form method="POST" action="{{ route('logout') }}" class="block">
+                    @csrf
+                    <button type="submit" class="w-full text-left px-4 py-2 text-sm text-red-500 hover:bg-gray-100 dark:hover:bg-gray-600">Logout</button>
+                </form>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- Use authenticated user's avatar in admin header
- Replace placeholder logout link with POST form for proper logout

## Testing
- `composer test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: CONNECT tunnel failed for GitHub packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d3100b448326b420982aa1ca342a