### PR TITLE
Add logout route and avatar initials fallback

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use App\Enums\Role;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 class User extends Authenticatable
 {
@@ -73,8 +74,17 @@ class User extends Authenticatable
             ->exists();
     }
 
-    public function getAvatarUrlAttribute(): string
+    public function getAvatarUrlAttribute(): ?string
     {
-        return 'https://ui-avatars.com/api/?name=' . urlencode($this->name);
+        return $this->attributes['avatar_url'] ?? null;
+    }
+
+    public function getInitialsAttribute(): string
+    {
+        return collect(explode(' ', $this->name))
+            ->filter()
+            ->map(fn (string $segment) => Str::upper(Str::substr($segment, 0, 1)))
+            ->take(2)
+            ->join('');
     }
 }

--- a/resources/views/livewire/admin/chat.blade.php
+++ b/resources/views/livewire/admin/chat.blade.php
@@ -10,7 +10,11 @@
                         wire:click="$set('recipient_id', {{ $user->id }})"
                         class="flex items-center justify-between p-2 rounded-lg cursor-pointer {{ $recipient_id == $user->id ? 'bg-indigo-50 dark:bg-gray-700' : 'hover:bg-gray-100 dark:hover:bg-gray-700' }}">
                         <div class="flex items-center space-x-2">
-                            <img src="{{ $user->avatar_url }}" class="w-6 h-6 rounded-full">
+                            @if ($user->avatar_url)
+                                <img src="{{ $user->avatar_url }}" class="w-6 h-6 rounded-full">
+                            @else
+                                <span class="w-6 h-6 rounded-full bg-gray-300 flex items-center justify-center text-xs font-semibold text-gray-700">{{ $user->initials }}</span>
+                            @endif
                             <span class="text-sm text-gray-800 dark:text-gray-100">{{ $user->name }}</span>
                         </div>
                         <div class="flex items-center space-x-1">
@@ -29,14 +33,22 @@
                 @forelse($messages as $msg)
                     <div class="flex items-end {{ $msg->user_id === auth()->id() ? 'justify-end' : 'justify-start' }}">
                         @if($msg->user_id !== auth()->id())
-                            <img src="{{ $msg->user->avatar_url }}" class="w-6 h-6 rounded-full mr-2">
+                            @if ($msg->user->avatar_url)
+                                <img src="{{ $msg->user->avatar_url }}" class="w-6 h-6 rounded-full mr-2">
+                            @else
+                                <span class="w-6 h-6 rounded-full bg-gray-300 flex items-center justify-center text-xs font-semibold text-gray-700 mr-2">{{ $msg->user->initials }}</span>
+                            @endif
                         @endif
                         <div class="max-w-xs px-3 py-2 rounded-lg text-sm {{ $msg->user_id === auth()->id() ? 'bg-indigo-600 text-white' : 'bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-100' }}">
                             <div>{{ $msg->message }}</div>
                             <div class="text-[10px] text-right mt-1 opacity-70">{{ $msg->created_at->format('H:i') }}</div>
                         </div>
                         @if($msg->user_id === auth()->id())
-                            <img src="{{ auth()->user()->avatar_url }}" class="w-6 h-6 rounded-full ml-2">
+                            @if (auth()->user()->avatar_url)
+                                <img src="{{ auth()->user()->avatar_url }}" class="w-6 h-6 rounded-full ml-2">
+                            @else
+                                <span class="w-6 h-6 rounded-full bg-gray-300 flex items-center justify-center text-xs font-semibold text-gray-700 ml-2">{{ auth()->user()->initials }}</span>
+                            @endif
                         @endif
                     </div>
                 @empty

--- a/resources/views/livewire/admin/partials/header.blade.php
+++ b/resources/views/livewire/admin/partials/header.blade.php
@@ -13,7 +13,13 @@
         </div>
         <div class="relative">
             <button id="userMenuButton" class="flex items-center gap-2">
-                <img class="h-9 w-9 rounded-full object-cover" src="{{ auth()->user()->avatar_url }}" alt="{{ auth()->user()->name }}">
+                @if (auth()->user()->avatar_url)
+                    <img class="h-9 w-9 rounded-full object-cover" src="{{ auth()->user()->avatar_url }}" alt="{{ auth()->user()->name }}">
+                @else
+                    <span class="h-9 w-9 rounded-full bg-gray-200 flex items-center justify-center text-sm font-semibold text-gray-700">
+                        {{ auth()->user()->initials }}
+                    </span>
+                @endif
             </button>
             <div id="userMenu" class="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-700 rounded-lg shadow-xl py-1 z-10 hidden">
                 <a href="{{ route('profile') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600">Profile</a>

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Auth\VerifyEmailController;
+use App\Livewire\Actions\Logout;
 use Illuminate\Support\Facades\Route;
 use Livewire\Volt\Volt;
 
@@ -28,4 +29,9 @@ Route::middleware('auth')->group(function () {
 
     Volt::route('confirm-password', 'pages.auth.confirm-password')
         ->name('password.confirm');
+
+    Route::post('logout', function (Logout $logout) {
+        $logout();
+        return redirect()->route('landing');
+    })->name('logout');
 });


### PR DESCRIPTION
## Summary
- Add authenticated logout route
- Show user initials when no avatar image is present
- Provide initials accessor on User model

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d6a732008326b140e3f57e26340c