### PR TITLE
Add role-based dashboards for different user roles

### DIFF
--- a/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -15,13 +15,13 @@ class VerifyEmailController extends Controller
     public function __invoke(EmailVerificationRequest $request): RedirectResponse
     {
         if ($request->user()->hasVerifiedEmail()) {
-            return redirect()->intended(route('admin.dashboard', absolute: false).'?verified=1');
+            return redirect()->intended(route('dashboard', absolute: false).'?verified=1');
         }
 
         if ($request->user()->markEmailAsVerified()) {
             event(new Verified($request->user()));
         }
 
-        return redirect()->intended(route('admin.dashboard', absolute: false).'?verified=1');
+        return redirect()->intended(route('dashboard', absolute: false).'?verified=1');
     }
 }

--- a/app/Livewire/Student/Dashboard.php
+++ b/app/Livewire/Student/Dashboard.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Livewire\Student;
+
+use Livewire\Component;
+
+class Dashboard extends Component
+{
+    public function render()
+    {
+        return view('livewire.student.dashboard')
+            ->layout('layouts.panel', ['title' => 'Student Dashboard']);
+    }
+}

--- a/app/Livewire/Teacher/Dashboard.php
+++ b/app/Livewire/Teacher/Dashboard.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Livewire\Teacher;
+
+use Livewire\Component;
+
+class Dashboard extends Component
+{
+    public function render()
+    {
+        return view('livewire.teacher.dashboard')
+            ->layout('layouts.panel', ['title' => 'Teacher Dashboard']);
+    }
+}

--- a/resources/views/frontend/landing.blade.php
+++ b/resources/views/frontend/landing.blade.php
@@ -5,7 +5,7 @@
     <h1 class="text-5xl font-bold mb-4">Welcome to MCQ Bank</h1>
     <p class="text-lg text-gray-600 mb-8">Practice and create multiple choice questions effortlessly.</p>
     @auth
-        <a href="{{ route('admin.dashboard') }}" class="px-6 py-3 bg-indigo-600 text-white rounded-md">Go to Dashboard</a>
+        <a href="{{ route('dashboard') }}" class="px-6 py-3 bg-indigo-600 text-white rounded-md">Go to Dashboard</a>
     @else
         <a href="{{ route('register') }}" class="px-6 py-3 bg-indigo-600 text-white rounded-md">Get Started</a>
     @endauth
@@ -31,7 +31,7 @@
 <section class="py-24 text-center bg-indigo-50">
     <h2 class="text-3xl font-bold mb-4">Ready to dive in?</h2>
     @auth
-        <a href="{{ route('admin.dashboard') }}" class="px-6 py-3 bg-indigo-600 text-white rounded-md">Go to Dashboard</a>
+        <a href="{{ route('dashboard') }}" class="px-6 py-3 bg-indigo-600 text-white rounded-md">Go to Dashboard</a>
     @else
         <a href="{{ route('register') }}" class="px-6 py-3 bg-indigo-600 text-white rounded-md">Create an Account</a>
     @endauth

--- a/resources/views/layouts/frontend.blade.php
+++ b/resources/views/layouts/frontend.blade.php
@@ -12,7 +12,7 @@
             <a href="/" class="text-xl font-bold">MCQ Bank</a>
             <nav class="space-x-4">
                 @auth
-                    <a href="{{ route('admin.dashboard') }}" class="text-sm text-gray-700 hover:text-gray-900">Dashboard</a>
+                    <a href="{{ route('dashboard') }}" class="text-sm text-gray-700 hover:text-gray-900">Dashboard</a>
                 @else
                     <a href="{{ route('login') }}" class="text-sm text-gray-700 hover:text-gray-900">Login</a>
                     <a href="{{ route('register') }}" class="text-sm text-gray-700 hover:text-gray-900">Register</a>

--- a/resources/views/layouts/panel.blade.php
+++ b/resources/views/layouts/panel.blade.php
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <title>{{ $title ?? 'MCQ Bank' }}</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @livewireStyles
+</head>
+<body class="font-sans antialiased">
+    <div class="min-h-screen bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200">
+        {{ $slot }}
+    </div>
+    @livewireScripts
+</body>
+</html>

--- a/resources/views/livewire/layout/navigation.blade.php
+++ b/resources/views/livewire/layout/navigation.blade.php
@@ -23,14 +23,14 @@ new class extends Component
             <div class="flex">
                 <!-- Logo -->
                 <div class="shrink-0 flex items-center">
-                    <a href="{{ route('admin.dashboard') }}" wire:navigate>
+                    <a href="{{ route('dashboard') }}" wire:navigate>
                         <x-application-logo class="block h-9 w-auto fill-current text-gray-800" />
                     </a>
                 </div>
 
                 <!-- Navigation Links -->
                 <div class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
-                    <x-nav-link :href="route('admin.dashboard')" :active="request()->routeIs('admin.dashboard')" wire:navigate>
+                    <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')" wire:navigate>
                         {{ __('Dashboard') }}
                     </x-nav-link>
                 </div>
@@ -81,7 +81,7 @@ new class extends Component
     <!-- Responsive Navigation Menu -->
     <div :class="{'block': open, 'hidden': ! open}" class="hidden sm:hidden">
         <div class="pt-2 pb-3 space-y-1">
-            <x-responsive-nav-link :href="route('admin.dashboard')" :active="request()->routeIs('admin.dashboard')" wire:navigate>
+            <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')" wire:navigate>
                 {{ __('Dashboard') }}
             </x-responsive-nav-link>
         </div>

--- a/resources/views/livewire/pages/auth/confirm-password.blade.php
+++ b/resources/views/livewire/pages/auth/confirm-password.blade.php
@@ -29,7 +29,7 @@ new #[Layout('layouts.guest')] class extends Component
 
         session(['auth.password_confirmed_at' => time()]);
 
-        $this->redirectIntended(default: route('admin.dashboard', absolute: false), navigate: true);
+        $this->redirectIntended(default: route('dashboard', absolute: false), navigate: true);
     }
 }; ?>
 

--- a/resources/views/livewire/pages/auth/login.blade.php
+++ b/resources/views/livewire/pages/auth/login.blade.php
@@ -20,7 +20,7 @@ new #[Layout('layouts.guest')] class extends Component
 
         Session::regenerate();
 
-        $this->redirectIntended(default: route('admin.dashboard', absolute: false), navigate: true);
+        $this->redirectIntended(default: route('dashboard', absolute: false), navigate: true);
     }
 }; ?>
 

--- a/resources/views/livewire/pages/auth/register.blade.php
+++ b/resources/views/livewire/pages/auth/register.blade.php
@@ -32,7 +32,7 @@ new #[Layout('layouts.guest')] class extends Component
 
         Auth::login($user);
 
-        $this->redirect(route('admin.dashboard', absolute: false), navigate: true);
+        $this->redirect(route('dashboard', absolute: false), navigate: true);
     }
 }; ?>
 

--- a/resources/views/livewire/pages/auth/verify-email.blade.php
+++ b/resources/views/livewire/pages/auth/verify-email.blade.php
@@ -14,7 +14,7 @@ new #[Layout('layouts.guest')] class extends Component
     public function sendVerification(): void
     {
         if (Auth::user()->hasVerifiedEmail()) {
-            $this->redirectIntended(default: route('admin.dashboard', absolute: false), navigate: true);
+            $this->redirectIntended(default: route('dashboard', absolute: false), navigate: true);
 
             return;
         }

--- a/resources/views/livewire/profile/update-profile-information-form.blade.php
+++ b/resources/views/livewire/profile/update-profile-information-form.blade.php
@@ -51,7 +51,7 @@ new class extends Component
         $user = Auth::user();
 
         if ($user->hasVerifiedEmail()) {
-            $this->redirectIntended(default: route('admin.dashboard', absolute: false));
+            $this->redirectIntended(default: route('dashboard', absolute: false));
 
             return;
         }

--- a/resources/views/livewire/student/dashboard.blade.php
+++ b/resources/views/livewire/student/dashboard.blade.php
@@ -1,0 +1,3 @@
+<div class="p-6">
+    <h1 class="text-2xl font-bold">Student Dashboard</h1>
+</div>

--- a/resources/views/livewire/teacher/dashboard.blade.php
+++ b/resources/views/livewire/teacher/dashboard.blade.php
@@ -1,0 +1,3 @@
+<div class="p-6">
+    <h1 class="text-2xl font-bold">Teacher Dashboard</h1>
+</div>

--- a/resources/views/livewire/welcome/navigation.blade.php
+++ b/resources/views/livewire/welcome/navigation.blade.php
@@ -1,7 +1,7 @@
 <nav class="-mx-3 flex flex-1 justify-end">
     @auth
         <a
-            href="{{ url('/admin/dashboard') }}"
+            href="{{ url('/dashboard') }}"
             class="rounded-md px-3 py-2 text-black ring-1 ring-transparent transition hover:text-black/70 focus:outline-none focus-visible:ring-[#FF2D20] dark:text-white dark:hover:text-white/80 dark:focus-visible:ring-white"
         >
             Dashboard

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Enums\Role;
 use App\Livewire\Admin\Dashboard;
 use App\Livewire\Admin\Questions;
 use App\Livewire\Admin\Questions\Create;
@@ -14,6 +15,8 @@ use App\Livewire\Admin\Chapters\Create as ChapterCreate;
 use App\Livewire\Admin\Chapters\Edit as ChapterEdit;
 use App\Livewire\Admin\Students\Index as StudentIndex;
 use App\Livewire\Admin\Tags\Index as TagIndex;
+use App\Livewire\Teacher\Dashboard as TeacherDashboard;
+use App\Livewire\Student\Dashboard as StudentDashboard;
 use App\Livewire\Practice;
 Route::view('/', 'frontend.landing')->name('landing');
 Route::view('/frontend', 'frontend.landing');
@@ -48,10 +51,28 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     // Route::get('/admin/students', StudentIndex::class)->name('admin.students.index');
 });
 
+Route::middleware(['auth', 'role:teacher'])->group(function () {
+    Route::get('/teacher/dashboard', TeacherDashboard::class)->name('teacher.dashboard');
+});
+
+Route::middleware(['auth', 'role:student'])->group(function () {
+    Route::get('/student/dashboard', StudentDashboard::class)->name('student.dashboard');
+});
+
 Route::middleware(['auth', 'role:teacher,student'])->group(function () {
     // Practice
 
 });
+
+Route::get('/dashboard', function () {
+    $user = request()->user();
+
+    return match ($user->role) {
+        Role::ADMIN => redirect()->route('admin.dashboard'),
+        Role::TEACHER => redirect()->route('teacher.dashboard'),
+        Role::STUDENT => redirect()->route('student.dashboard'),
+    };
+})->middleware('auth')->name('dashboard');
 
 Route::middleware('auth')->group(function () {
     Route::view('/profile', 'profile')->name('profile');

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Auth;
 
 use App\Models\User;
+use App\Enums\Role;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Volt\Volt;
 use Tests\TestCase;
@@ -32,7 +33,7 @@ class AuthenticationTest extends TestCase
 
         $component
             ->assertHasNoErrors()
-            ->assertRedirect(route('admin.dashboard', absolute: false));
+            ->assertRedirect(route('dashboard', absolute: false));
 
         $this->assertAuthenticated();
     }
@@ -56,7 +57,7 @@ class AuthenticationTest extends TestCase
 
     public function test_navigation_menu_can_be_rendered(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->create(['role' => Role::ADMIN]);
 
         $this->actingAs($user);
 

--- a/tests/Feature/Auth/EmailVerificationTest.php
+++ b/tests/Feature/Auth/EmailVerificationTest.php
@@ -40,7 +40,7 @@ class EmailVerificationTest extends TestCase
 
         Event::assertDispatched(Verified::class);
         $this->assertTrue($user->fresh()->hasVerifiedEmail());
-        $response->assertRedirect(route('admin.dashboard', absolute: false).'?verified=1');
+        $response->assertRedirect(route('dashboard', absolute: false).'?verified=1');
     }
 
     public function test_email_is_not_verified_with_invalid_hash(): void

--- a/tests/Feature/Auth/PasswordConfirmationTest.php
+++ b/tests/Feature/Auth/PasswordConfirmationTest.php
@@ -34,7 +34,7 @@ class PasswordConfirmationTest extends TestCase
         $component->call('confirmPassword');
 
         $component
-            ->assertRedirect('/admin/dashboard')
+            ->assertRedirect('/dashboard')
             ->assertHasNoErrors();
     }
 

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -29,7 +29,7 @@ class RegistrationTest extends TestCase
 
         $component->call('register');
 
-        $component->assertRedirect(route('admin.dashboard', absolute: false));
+        $component->assertRedirect(route('dashboard', absolute: false));
 
         $this->assertAuthenticated();
     }


### PR DESCRIPTION
## Summary
- add teacher and student dashboards with shared panel layout
- route `/dashboard` to role-specific dashboards
- update auth views and tests to use the new dashboard route

## Testing
- `composer test` *(fails: require vendor/autoload.php: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d9102c9883268391fca03eb73e19