### PR TITLE
Add admin user role management

### DIFF
--- a/app/Livewire/Admin/Users/Index.php
+++ b/app/Livewire/Admin/Users/Index.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Livewire\Admin\Users;
+
+use App\Enums\Role;
+use App\Models\User;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class Index extends Component
+{
+    use WithPagination;
+
+    public string $search = '';
+
+    public function updatingSearch(): void
+    {
+        $this->resetPage();
+    }
+
+    public function changeRole(int $userId, string $role): void
+    {
+        $user = User::findOrFail($userId);
+        $user->update(['role' => $role]);
+        $this->dispatch('roleUpdated', message: 'Role updated successfully.');
+    }
+
+    public function render()
+    {
+        $users = User::when($this->search, function ($q) {
+                $q->where('name', 'like', '%'.$this->search.'%')
+                  ->orWhere('email', 'like', '%'.$this->search.'%');
+            })
+            ->orderBy('name')
+            ->paginate(10);
+
+        return view('livewire.admin.users.index', [
+            'users' => $users,
+            'roles' => Role::cases(),
+        ])->layout('layouts.admin', ['title' => 'Users']);
+    }
+}

--- a/resources/views/livewire/admin/partials/sidebar.blade.php
+++ b/resources/views/livewire/admin/partials/sidebar.blade.php
@@ -69,10 +69,10 @@
             <span class="sidebar-text">Settings</span>
         </a>
 
-        <a href=""
-           class="nav-link flex items-center gap-3 px-4 py-2.5 rounded-lg {{ request()->is('admin/students*') ? 'bg-indigo-50 dark:bg-gray-700 text-indigo-600 dark:text-indigo-400 font-semibold' : '' }}">
+        <a wire:navigate href="{{ route('admin.users.index') }}"
+           class="nav-link flex items-center gap-3 px-4 py-2.5 rounded-lg {{ request()->is('admin/users*') ? 'bg-indigo-50 dark:bg-gray-700 text-indigo-600 dark:text-indigo-400 font-semibold' : '' }}">
             <x-heroicon-o-user-group class="w-5 h-5"/>
-            <span class="sidebar-text">Students</span>
+            <span class="sidebar-text">Users</span>
         </a>
     </nav>
 

--- a/resources/views/livewire/admin/users/index.blade.php
+++ b/resources/views/livewire/admin/users/index.blade.php
@@ -1,0 +1,60 @@
+<div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+    <div class="flex flex-col sm:flex-row sm:justify-between gap-4 mb-4">
+        <input type="text" wire:model.live.debounce.300ms="search" placeholder="Search users..."
+               class="flex-1 px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
+    </div>
+
+    <div class="overflow-x-auto">
+        <table class="min-w-full text-sm divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-700">
+            <tr>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">#</th>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Name</th>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Email</th>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Role</th>
+            </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+            @forelse($users as $user)
+                <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+                    <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $user->id }}</td>
+                    <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $user->name }}</td>
+                    <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $user->email }}</td>
+                    <td class="px-4 py-2">
+                        <select class="px-2 py-1 border border-gray-300 rounded-md dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" wire:change="changeRole({{ $user->id }}, $event.target.value)">
+                            @foreach($roles as $roleOption)
+                                <option value="{{ $roleOption->value }}" @selected($user->role === $roleOption)>{{ ucfirst($roleOption->value) }}</option>
+                            @endforeach
+                        </select>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="4" class="px-4 py-6 text-center text-gray-500 dark:text-gray-400">No users found.</td>
+                </tr>
+            @endforelse
+            </tbody>
+        </table>
+    </div>
+    <div class="mt-4">{{ $users->links() }}</div>
+</div>
+
+@push('scripts')
+<script>
+    function showToast(message) {
+        if (!window.Swal) return;
+        Swal.fire({
+            toast: true,
+            icon: 'success',
+            title: message,
+            position: 'top-end',
+            showConfirmButton: false,
+            timer: 1500,
+        });
+    }
+
+    window.addEventListener('roleUpdated', e => {
+        showToast(e.detail.message || 'Role updated successfully.');
+    });
+</script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,8 +13,8 @@ use App\Livewire\Admin\Subjects\Edit as SubjectEdit;
 use App\Livewire\Admin\Chapters\Index as ChapterIndex;
 use App\Livewire\Admin\Chapters\Create as ChapterCreate;
 use App\Livewire\Admin\Chapters\Edit as ChapterEdit;
-use App\Livewire\Admin\Students\Index as StudentIndex;
 use App\Livewire\Admin\Tags\Index as TagIndex;
+use App\Livewire\Admin\Users\Index as UserIndex;
 use App\Livewire\Teacher\Dashboard as TeacherDashboard;
 use App\Livewire\Student\Dashboard as StudentDashboard;
 use App\Livewire\Practice;
@@ -47,8 +47,8 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     // Settings
     Route::get('/admin/settings', Settings::class)->name('admin.settings');
 
-    // Students
-    // Route::get('/admin/students', StudentIndex::class)->name('admin.students.index');
+    // Users
+    Route::get('/admin/users', UserIndex::class)->name('admin.users.index');
 });
 
 Route::middleware(['auth', 'role:teacher'])->group(function () {

--- a/tests/Feature/Admin/ManageUserRolesTest.php
+++ b/tests/Feature/Admin/ManageUserRolesTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\Role;
+use App\Livewire\Admin\Users\Index;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ManageUserRolesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_update_user_role(): void
+    {
+        $admin = User::factory()->create(['role' => Role::ADMIN]);
+        $user = User::factory()->create(['role' => Role::STUDENT]);
+
+        $this->actingAs($admin);
+
+        Livewire::test(Index::class)
+            ->call('changeRole', $user->id, Role::TEACHER->value);
+
+        $this->assertEquals(Role::TEACHER, $user->fresh()->role);
+    }
+}


### PR DESCRIPTION
## Summary
- Add Livewire component and view for managing user roles from the admin panel
- Link users management page in sidebar and register new route
- Include feature test covering admin role updates

## Testing
- `composer test` *(fails: Script @php artisan config:clear --ansi handling the test event returned with error code 255)*
- `composer install` *(fails: curl error 56 while downloading packages from GitHub)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ebae1dbc8326945ebad50a41d211