### PR TITLE
Add role-based panels and exam tracking

### DIFF
--- a/app/Livewire/Admin/Questions.php
+++ b/app/Livewire/Admin/Questions.php
@@ -96,7 +96,7 @@ class Questions extends Component
             'chapters' => Chapter::when($this->subjectId, fn($q) => $q->where('subject_id', $this->subjectId))
                 ->orderBy('name')
                 ->get(),
-        ])->layout('layouts.admin', ['title' => 'Manage Questions']);
+        ])->layout($user->isAdmin() ? 'layouts.admin' : 'layouts.panel', ['title' => 'Manage Questions']);
     }
 }
 

--- a/app/Livewire/Student/Dashboard.php
+++ b/app/Livewire/Student/Dashboard.php
@@ -3,12 +3,34 @@
 namespace App\Livewire\Student;
 
 use Livewire\Component;
+use App\Models\ExamResult;
 
 class Dashboard extends Component
 {
     public function render()
     {
-        return view('livewire.student.dashboard')
-            ->layout('layouts.panel', ['title' => 'Student Dashboard']);
+        $user = auth()->user();
+
+        $latest = ExamResult::where('user_id', $user->id)->latest()->first();
+
+        $daily = ExamResult::where('user_id', $user->id)
+            ->where('created_at', '>=', now()->subDays(6)->startOfDay())
+            ->selectRaw('DATE(created_at) as date, COUNT(*) as total')
+            ->groupBy('date')
+            ->orderBy('date')
+            ->get();
+
+        $weekly = ExamResult::where('user_id', $user->id)
+            ->where('created_at', '>=', now()->subWeeks(5)->startOfWeek())
+            ->selectRaw('YEARWEEK(created_at, 1) as week, COUNT(*) as total')
+            ->groupBy('week')
+            ->orderBy('week')
+            ->get();
+
+        return view('livewire.student.dashboard', [
+            'latest' => $latest,
+            'daily' => $daily,
+            'weekly' => $weekly,
+        ])->layout('layouts.panel', ['title' => 'Student Dashboard']);
     }
 }

--- a/app/Livewire/Teacher/Dashboard.php
+++ b/app/Livewire/Teacher/Dashboard.php
@@ -3,12 +3,22 @@
 namespace App\Livewire\Teacher;
 
 use Livewire\Component;
+use App\Models\{Question, Subject};
 
 class Dashboard extends Component
 {
     public function render()
     {
-        return view('livewire.teacher.dashboard')
-            ->layout('layouts.panel', ['title' => 'Teacher Dashboard']);
+        $user = auth()->user();
+
+        $questionCount = Question::where('user_id', $user->id)->count();
+        $subjects = Subject::withCount(['questions' => fn($q) => $q->where('user_id', $user->id)])
+            ->orderBy('name')
+            ->get();
+
+        return view('livewire.teacher.dashboard', [
+            'questionCount' => $questionCount,
+            'subjects' => $subjects,
+        ])->layout('layouts.panel', ['title' => 'Teacher Dashboard']);
     }
 }

--- a/app/Models/ExamResult.php
+++ b/app/Models/ExamResult.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ExamResult extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'score',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2025_08_14_231808_create_exam_results_table.php
+++ b/database/migrations/2025_08_14_231808_create_exam_results_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('exam_results', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->unsignedInteger('score');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('exam_results');
+    }
+};

--- a/resources/views/layouts/panel.blade.php
+++ b/resources/views/layouts/panel.blade.php
@@ -10,8 +10,13 @@
 </head>
 <body class="font-sans antialiased">
     <div class="min-h-screen bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200">
-        {{ $slot }}
+        <livewire:layout.navigation />
+
+        <main class="p-6">
+            {{ $slot }}
+        </main>
     </div>
     @livewireScripts
+    @stack('scripts')
 </body>
 </html>

--- a/resources/views/livewire/layout/navigation.blade.php
+++ b/resources/views/livewire/layout/navigation.blade.php
@@ -33,6 +33,18 @@ new class extends Component
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')" wire:navigate>
                         {{ __('Dashboard') }}
                     </x-nav-link>
+
+                    @if(auth()->user()->isTeacher())
+                        <x-nav-link :href="route('teacher.questions.index')" :active="request()->routeIs('teacher.questions.*')" wire:navigate>
+                            {{ __('Questions') }}
+                        </x-nav-link>
+                    @endif
+
+                    @if(auth()->user()->isTeacher() || auth()->user()->isStudent())
+                        <x-nav-link :href="route('practice')" :active="request()->routeIs('practice')" wire:navigate>
+                            {{ __('Practice') }}
+                        </x-nav-link>
+                    @endif
                 </div>
             </div>
 
@@ -84,6 +96,18 @@ new class extends Component
             <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')" wire:navigate>
                 {{ __('Dashboard') }}
             </x-responsive-nav-link>
+
+            @if(auth()->user()->isTeacher())
+                <x-responsive-nav-link :href="route('teacher.questions.index')" :active="request()->routeIs('teacher.questions.*')" wire:navigate>
+                    {{ __('Questions') }}
+                </x-responsive-nav-link>
+            @endif
+
+            @if(auth()->user()->isTeacher() || auth()->user()->isStudent())
+                <x-responsive-nav-link :href="route('practice')" :active="request()->routeIs('practice')" wire:navigate>
+                    {{ __('Practice') }}
+                </x-responsive-nav-link>
+            @endif
         </div>
 
         <!-- Responsive Settings Options -->

--- a/resources/views/livewire/practice.blade.php
+++ b/resources/views/livewire/practice.blade.php
@@ -1,4 +1,20 @@
 <div>
+    <div class="mb-4 flex flex-col sm:flex-row gap-2">
+        <select wire:model="subjectId" class="border rounded px-3 py-2">
+            <option value="">All Subjects</option>
+            @foreach($subjects as $subject)
+                <option value="{{ $subject->id }}">{{ $subject->name }}</option>
+            @endforeach
+        </select>
+        <select wire:model="chapterId" class="border rounded px-3 py-2">
+            <option value="">All Chapters</option>
+            @foreach($chapters as $chapter)
+                <option value="{{ $chapter->id }}">{{ $chapter->name }}</option>
+            @endforeach
+        </select>
+        <button wire:click="loadRandom" class="bg-indigo-500 text-white px-4 py-2 rounded">Load</button>
+    </div>
+
     @if($current)
         <div class="mb-4 prose max-w-none">{!! $current->title !!}</div>
 

--- a/resources/views/livewire/student/dashboard.blade.php
+++ b/resources/views/livewire/student/dashboard.blade.php
@@ -1,3 +1,49 @@
-<div class="p-6">
+<div class="space-y-6">
     <h1 class="text-2xl font-bold">Student Dashboard</h1>
+
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div class="p-4 bg-white dark:bg-gray-800 rounded shadow">
+            <div class="text-sm text-gray-500">Last Score</div>
+            <div class="text-2xl font-semibold">
+                {{ $latest?->score ?? 'N/A' }}
+            </div>
+        </div>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+            <h2 class="font-semibold mb-2">Daily Exams</h2>
+            <div id="dailyChart" class="h-64"></div>
+        </div>
+        <div>
+            <h2 class="font-semibold mb-2">Weekly Exams</h2>
+            <div id="weeklyChart" class="h-64"></div>
+        </div>
+    </div>
 </div>
+
+@push('scripts')
+<script>
+document.addEventListener('livewire:load', () => {
+    const dailyData = {
+        categories: {!! json_encode($daily->pluck('date')) !!},
+        series: {!! json_encode($daily->pluck('total')) !!}
+    };
+    new ApexCharts(document.querySelector('#dailyChart'), {
+        chart: { type: 'bar', height: 250 },
+        series: [{ name: 'Exams', data: dailyData.series }],
+        xaxis: { categories: dailyData.categories }
+    }).render();
+
+    const weeklyData = {
+        categories: {!! json_encode($weekly->pluck('week')) !!},
+        series: {!! json_encode($weekly->pluck('total')) !!}
+    };
+    new ApexCharts(document.querySelector('#weeklyChart'), {
+        chart: { type: 'line', height: 250 },
+        series: [{ name: 'Exams', data: weeklyData.series }],
+        xaxis: { categories: weeklyData.categories }
+    }).render();
+});
+</script>
+@endpush

--- a/resources/views/livewire/teacher/dashboard.blade.php
+++ b/resources/views/livewire/teacher/dashboard.blade.php
@@ -1,3 +1,32 @@
-<div class="p-6">
+<div class="space-y-6">
     <h1 class="text-2xl font-bold">Teacher Dashboard</h1>
+
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div class="p-4 bg-white dark:bg-gray-800 rounded shadow">
+            <div class="text-sm text-gray-500">Total Questions</div>
+            <div class="text-2xl font-semibold">{{ $questionCount }}</div>
+        </div>
+    </div>
+
+    <div>
+        <h2 class="text-xl font-semibold mb-2">Questions by Subject</h2>
+        <div id="subjectChart" class="h-64"></div>
+    </div>
 </div>
+
+@push('scripts')
+<script>
+document.addEventListener('livewire:load', () => {
+    const data = {
+        categories: {!! json_encode($subjects->pluck('name')) !!},
+        series: {!! json_encode($subjects->pluck('questions_count')) !!}
+    };
+    const chart = new ApexCharts(document.querySelector('#subjectChart'), {
+        chart: { type: 'bar', height: 250 },
+        series: [{ name: 'Questions', data: data.series }],
+        xaxis: { categories: data.categories }
+    });
+    chart.render();
+});
+</script>
+@endpush


### PR DESCRIPTION
## Summary
- Add shared panel layout with role-aware navigation
- Enable subject and chapter filtering during practice sessions
- Introduce teacher stats and student exam tracking with charts

## Testing
- `php artisan test` *(fails: vendor autoload missing; composer install requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ef3e066c8326800299d13579d423