### PR TITLE
Set Shurjo and Roboto as default fonts

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,7 +12,7 @@ export default {
     theme: {
         extend: {
             fontFamily: {
-                sans: ['Figtree', ...defaultTheme.fontFamily.sans],
+                sans: ['Shurjo','Roboto', ...defaultTheme.fontFamily.sans],
             },
         },
     },


### PR DESCRIPTION
## Summary
- Use Shurjo and Roboto as the default sans-serif fonts in Tailwind config to ensure Bengali and Roboto fonts load across the site

## Testing
- `npm run build`
- `php artisan test` *(fails: Failed to open vendor/autoload.php; composer install requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68a842a80abc8326bd5670f480a4b807