### PR TITLE
Fix teacher question authorization checks

### DIFF
--- a/app/Policies/QuestionPolicy.php
+++ b/app/Policies/QuestionPolicy.php
@@ -14,7 +14,7 @@ class QuestionPolicy
 
     public function view(User $user, Question $question): bool
     {
-        return $user->isAdmin() || $question->user_id === $user->id;
+        return $user->isAdmin() || $question->user_id == $user->id;
     }
 
     public function create(User $user): bool
@@ -24,7 +24,7 @@ class QuestionPolicy
 
     public function update(User $user, Question $question): bool
     {
-        return $user->isAdmin() || ($user->isTeacher() && $question->user_id === $user->id);
+        return $user->isAdmin() || ($user->isTeacher() && $question->user_id == $user->id);
     }
 
     public function delete(User $user, Question $question): bool


### PR DESCRIPTION
## Summary
- allow teachers to view and update their own questions even when model IDs are cast as strings

## Testing
- `composer test` *(fails: Script @php artisan config:clear --ansi handling the test event returned with error code 255)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68a85e4a88c88326bba0a4ba50cfbd5b