### PR TITLE
Fix teacher navigation and question permissions

### DIFF
--- a/app/Livewire/Admin/Questions/Create.php
+++ b/app/Livewire/Admin/Questions/Create.php
@@ -69,10 +69,12 @@ class Create extends Component
 
     public function render()
     {
+        $layout = auth()->user()->isAdmin() ? 'layouts.admin' : 'layouts.panel';
+
         return view('livewire.admin.questions.create', [
             'subjects' => Subject::all(),
             'chapters' => Chapter::where('subject_id', $this->subject_id)->get(),
             'allTags' => Tag::all(),
-        ])->layout('layouts.admin', ['title' => 'Create Question']);
+        ])->layout($layout, ['title' => 'Create Question']);
     }
 }

--- a/app/Livewire/Admin/Questions/Edit.php
+++ b/app/Livewire/Admin/Questions/Edit.php
@@ -74,10 +74,12 @@ class Edit extends Component
 
     public function render()
     {
+        $layout = auth()->user()->isAdmin() ? 'layouts.admin' : 'layouts.panel';
+
         return view('livewire.admin.questions.edit', [
             'subjects' => Subject::all(),
             'chapters' => Chapter::where('subject_id', $this->subject_id)->get(),
             'allTags' => Tag::all(),
-        ])->layout('layouts.admin', ['title' => 'Edit Question']);
+        ])->layout($layout, ['title' => 'Edit Question']);
     }
 }

--- a/resources/views/livewire/admin/partials/header.blade.php
+++ b/resources/views/livewire/admin/partials/header.blade.php
@@ -23,7 +23,9 @@
             </button>
             <div id="userMenu" class="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-700 rounded-lg shadow-xl py-1 z-10 hidden">
                 <a href="{{ route('profile') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600">Profile</a>
-                <a href="{{ route('admin.settings') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600">Settings</a>
+                @if(auth()->user()->isAdmin())
+                    <a href="{{ route('admin.settings') }}" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600">Settings</a>
+                @endif
                 <hr class="border-gray-200 dark:border-gray-600 my-1">
                 <form method="POST" action="{{ route('logout') }}" class="block">
                     @csrf

--- a/resources/views/livewire/admin/partials/sidebar.blade.php
+++ b/resources/views/livewire/admin/partials/sidebar.blade.php
@@ -16,8 +16,11 @@
 
     {{-- Nav --}}
     <nav class="flex-1 px-4 py-4 space-y-2 overflow-y-auto">
-        <a href="{{ route('admin.dashboard') }}"
-           class="nav-link flex items-center gap-3 px-4 py-2.5 rounded-lg {{ request()->is('admin/dashboard') ? 'bg-indigo-50 dark:bg-gray-700 text-indigo-600 dark:text-indigo-400 font-semibold' : '' }}">
+        @php
+            $dashboardRoute = auth()->user()->isAdmin() ? 'admin.dashboard' : 'teacher.dashboard';
+        @endphp
+        <a href="{{ route($dashboardRoute) }}"
+           class="nav-link flex items-center gap-3 px-4 py-2.5 rounded-lg {{ request()->routeIs($dashboardRoute) ? 'bg-indigo-50 dark:bg-gray-700 text-indigo-600 dark:text-indigo-400 font-semibold' : '' }}">
             <x-heroicon-o-chart-bar class="w-5 h-5"/>
             <span class="sidebar-text">Dashboard</span>
         </a>

--- a/resources/views/livewire/admin/questions.blade.php
+++ b/resources/views/livewire/admin/questions.blade.php
@@ -18,7 +18,7 @@
                 @endforeach
             </select>
         </div>
-        <a wire:navigate href="{{ route('admin.questions.create') }}"
+        <a wire:navigate href="{{ route(auth()->user()->isAdmin() ? 'admin.questions.create' : 'teacher.questions.create') }}"
            class="inline-flex items-center justify-center px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500">
             + New Question
         </a>
@@ -43,10 +43,12 @@
                     <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $q->subject->name }}</td>
                     <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $q->chapter->name }}</td>
                     <td class="px-4 py-2 space-x-2">
-                        <a wire:navigate href="{{ route('admin.questions.edit', $q) }}"
+                        <a wire:navigate href="{{ route(auth()->user()->isAdmin() ? 'admin.questions.edit' : 'teacher.questions.edit', $q) }}"
                            class="text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300">Edit</a>
-                        <button type="button" onclick="confirmDelete({{ $q->id }})"
-                                class="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300">Delete</button>
+                        @if(auth()->user()->isAdmin())
+                            <button type="button" onclick="confirmDelete({{ $q->id }})"
+                                    class="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300">Delete</button>
+                        @endif
                     </td>
                 </tr>
             @empty


### PR DESCRIPTION
## Summary
- Show teacher dashboard link in sidebar when logged in as a teacher
- Use role-aware routes and hide delete for teachers on question list
- Apply correct layout for teacher question create/edit screens and hide admin settings link

## Testing
- `composer install` *(fails: CONNECT tunnel failed, requires GitHub token)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a863fbdce88326a4c58c2cfa39169a