### PR TITLE
feat: add job post module

### DIFF
--- a/app/Enums/JobStatus.php
+++ b/app/Enums/JobStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum JobStatus: string
+{
+    case DRAFT = 'draft';
+    case PUBLISHED = 'published';
+    case CLOSED = 'closed';
+}

--- a/app/Livewire/Admin/Jobs/Create.php
+++ b/app/Livewire/Admin/Jobs/Create.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Livewire\Admin\Jobs;
+
+use Livewire\Component;
+use App\Models\JobPost;
+use App\Enums\JobStatus;
+
+class Create extends Component
+{
+    public $title;
+    public $slug;
+    public $category_id;
+    public $company_name;
+    public $summary;
+    public $description;
+    public $deadline;
+    public $posted_at;
+    public $status = JobStatus::DRAFT;
+    public $featured = false;
+    public $cover_image;
+    public $seo_title;
+    public $seo_description;
+    public $seo_keywords;
+
+    public function save()
+    {
+        $this->validate([
+            'title' => 'required|string|max:255',
+            'slug' => 'required|string|max:255|unique:job_posts,slug',
+            'category_id' => 'nullable|integer',
+            'company_name' => 'nullable|string|max:255',
+            'summary' => 'nullable|string|max:255',
+            'description' => 'nullable|string',
+            'deadline' => 'nullable|date',
+            'posted_at' => 'nullable|date',
+            'status' => 'required|in:'.implode(',', array_column(JobStatus::cases(), 'value')),
+            'featured' => 'boolean',
+            'cover_image' => 'nullable|string|max:255',
+            'seo_title' => 'nullable|string|max:255',
+            'seo_description' => 'nullable|string',
+            'seo_keywords' => 'nullable|string|max:255',
+        ]);
+
+        JobPost::create([
+            'title' => $this->title,
+            'slug' => $this->slug,
+            'category_id' => $this->category_id,
+            'company_name' => $this->company_name,
+            'summary' => $this->summary,
+            'description' => $this->description,
+            'deadline' => $this->deadline,
+            'posted_at' => $this->posted_at,
+            'status' => $this->status,
+            'featured' => $this->featured,
+            'cover_image' => $this->cover_image,
+            'seo_title' => $this->seo_title,
+            'seo_description' => $this->seo_description,
+            'seo_keywords' => $this->seo_keywords,
+        ]);
+
+        return redirect()->route('admin.jobs.index')
+            ->with('success', 'Job created.');
+    }
+
+    public function render()
+    {
+        return view('livewire.admin.jobs.create')
+            ->layout('layouts.admin', ['title' => 'Create Job']);
+    }
+}

--- a/app/Livewire/Admin/Jobs/Edit.php
+++ b/app/Livewire/Admin/Jobs/Edit.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Livewire\Admin\Jobs;
+
+use Livewire\Component;
+use App\Models\JobPost;
+use App\Enums\JobStatus;
+
+class Edit extends Component
+{
+    public JobPost $job;
+    public $title;
+    public $slug;
+    public $category_id;
+    public $company_name;
+    public $summary;
+    public $description;
+    public $deadline;
+    public $posted_at;
+    public $status;
+    public $featured;
+    public $cover_image;
+    public $seo_title;
+    public $seo_description;
+    public $seo_keywords;
+
+    public function mount(JobPost $job)
+    {
+        $this->job = $job;
+        $this->title = $job->title;
+        $this->slug = $job->slug;
+        $this->category_id = $job->category_id;
+        $this->company_name = $job->company_name;
+        $this->summary = $job->summary;
+        $this->description = $job->description;
+        $this->deadline = optional($job->deadline)->format('Y-m-d');
+        $this->posted_at = optional($job->posted_at)->format('Y-m-d\TH:i');
+        $this->status = $job->status->value;
+        $this->featured = $job->featured;
+        $this->cover_image = $job->cover_image;
+        $this->seo_title = $job->seo_title;
+        $this->seo_description = $job->seo_description;
+        $this->seo_keywords = $job->seo_keywords;
+    }
+
+    public function update()
+    {
+        $this->validate([
+            'title' => 'required|string|max:255',
+            'slug' => 'required|string|max:255|unique:job_posts,slug,' . $this->job->id,
+            'category_id' => 'nullable|integer',
+            'company_name' => 'nullable|string|max:255',
+            'summary' => 'nullable|string|max:255',
+            'description' => 'nullable|string',
+            'deadline' => 'nullable|date',
+            'posted_at' => 'nullable|date',
+            'status' => 'required|in:'.implode(',', array_column(JobStatus::cases(), 'value')),
+            'featured' => 'boolean',
+            'cover_image' => 'nullable|string|max:255',
+            'seo_title' => 'nullable|string|max:255',
+            'seo_description' => 'nullable|string',
+            'seo_keywords' => 'nullable|string|max:255',
+        ]);
+
+        $this->job->update([
+            'title' => $this->title,
+            'slug' => $this->slug,
+            'category_id' => $this->category_id,
+            'company_name' => $this->company_name,
+            'summary' => $this->summary,
+            'description' => $this->description,
+            'deadline' => $this->deadline,
+            'posted_at' => $this->posted_at,
+            'status' => $this->status,
+            'featured' => $this->featured,
+            'cover_image' => $this->cover_image,
+            'seo_title' => $this->seo_title,
+            'seo_description' => $this->seo_description,
+            'seo_keywords' => $this->seo_keywords,
+        ]);
+
+        return redirect()->route('admin.jobs.index')
+            ->with('success', 'Job updated.');
+    }
+
+    public function render()
+    {
+        return view('livewire.admin.jobs.edit')
+            ->layout('layouts.admin', ['title' => 'Edit Job']);
+    }
+}

--- a/app/Livewire/Admin/Jobs/Index.php
+++ b/app/Livewire/Admin/Jobs/Index.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Livewire\Admin\Jobs;
+
+use Livewire\Component;
+use Livewire\WithPagination;
+use App\Models\JobPost;
+
+class Index extends Component
+{
+    use WithPagination;
+
+    public $search = '';
+
+    protected $listeners = [
+        'jobDeleted' => '$refresh',
+        'deleteJobConfirmed' => 'delete',
+    ];
+
+    public function updatingSearch(): void
+    {
+        $this->resetPage();
+    }
+
+    public function delete($id): void
+    {
+        JobPost::findOrFail($id)->delete();
+        $this->resetPage();
+        $this->dispatch('jobDeleted', message: 'Job deleted successfully.');
+    }
+
+    public function render()
+    {
+        $jobs = JobPost::when($this->search, function ($query) {
+                $query->where('title', 'like', '%'.$this->search.'%')
+                      ->orWhere('company_name', 'like', '%'.$this->search.'%');
+            })
+            ->orderByDesc('created_at')
+            ->paginate(10);
+
+        return view('livewire.admin.jobs.index', [
+            'jobs' => $jobs,
+        ])->layout('layouts.admin', ['title' => 'Manage Jobs']);
+    }
+}

--- a/app/Models/JobPost.php
+++ b/app/Models/JobPost.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use App\Enums\JobStatus;
+
+class JobPost extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'title',
+        'slug',
+        'category_id',
+        'company_name',
+        'summary',
+        'description',
+        'deadline',
+        'posted_at',
+        'status',
+        'featured',
+        'cover_image',
+        'seo_title',
+        'seo_description',
+        'seo_keywords',
+    ];
+
+    protected $casts = [
+        'deadline' => 'date',
+        'posted_at' => 'datetime',
+        'featured' => 'boolean',
+        'status' => JobStatus::class,
+    ];
+}

--- a/database/migrations/2025_08_22_000000_create_job_posts_table.php
+++ b/database/migrations/2025_08_22_000000_create_job_posts_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('job_posts', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->string('slug')->unique();
+            $table->unsignedBigInteger('category_id')->nullable();
+            $table->string('company_name')->nullable();
+            $table->string('summary')->nullable();
+            $table->longText('description')->nullable();
+            $table->date('deadline')->nullable();
+            $table->timestamp('posted_at')->nullable();
+            $table->enum('status', ['draft', 'published', 'closed'])->default('draft');
+            $table->boolean('featured')->default(false);
+            $table->string('cover_image')->nullable();
+            $table->string('seo_title')->nullable();
+            $table->text('seo_description')->nullable();
+            $table->string('seo_keywords')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('job_posts');
+    }
+};
+

--- a/resources/views/livewire/admin/jobs/create.blade.php
+++ b/resources/views/livewire/admin/jobs/create.blade.php
@@ -1,0 +1,71 @@
+<div class="max-w-3xl mx-auto bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
+    <form wire:submit.prevent="save" class="space-y-4">
+        <div>
+            <label class="block mb-1 text-sm font-medium">Title</label>
+            <input type="text" wire:model="title" class="w-full px-3 py-2 border rounded" />
+        </div>
+        <div>
+            <label class="block mb-1 text-sm font-medium">Slug</label>
+            <input type="text" wire:model="slug" class="w-full px-3 py-2 border rounded" />
+        </div>
+        <div>
+            <label class="block mb-1 text-sm font-medium">Category ID</label>
+            <input type="number" wire:model="category_id" class="w-full px-3 py-2 border rounded" />
+        </div>
+        <div>
+            <label class="block mb-1 text-sm font-medium">Company Name</label>
+            <input type="text" wire:model="company_name" class="w-full px-3 py-2 border rounded" />
+        </div>
+        <div>
+            <label class="block mb-1 text-sm font-medium">Summary</label>
+            <textarea wire:model="summary" class="w-full px-3 py-2 border rounded"></textarea>
+        </div>
+        <div>
+            <label class="block mb-1 text-sm font-medium">Description</label>
+            <textarea wire:model="description" class="w-full px-3 py-2 border rounded"></textarea>
+        </div>
+        <div class="grid grid-cols-2 gap-4">
+            <div>
+                <label class="block mb-1 text-sm font-medium">Deadline</label>
+                <input type="date" wire:model="deadline" class="w-full px-3 py-2 border rounded" />
+            </div>
+            <div>
+                <label class="block mb-1 text-sm font-medium">Posted At</label>
+                <input type="datetime-local" wire:model="posted_at" class="w-full px-3 py-2 border rounded" />
+            </div>
+        </div>
+        <div class="grid grid-cols-2 gap-4">
+            <div>
+                <label class="block mb-1 text-sm font-medium">Status</label>
+                <select wire:model="status" class="w-full px-3 py-2 border rounded">
+                    @foreach(\App\Enums\JobStatus::cases() as $status)
+                        <option value="{{ $status->value }}">{{ ucfirst($status->value) }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="flex items-center mt-6">
+                <input type="checkbox" wire:model="featured" id="featured" class="mr-2" />
+                <label for="featured" class="text-sm">Featured</label>
+            </div>
+        </div>
+        <div>
+            <label class="block mb-1 text-sm font-medium">Cover Image</label>
+            <input type="text" wire:model="cover_image" class="w-full px-3 py-2 border rounded" />
+        </div>
+        <div>
+            <label class="block mb-1 text-sm font-medium">SEO Title</label>
+            <input type="text" wire:model="seo_title" class="w-full px-3 py-2 border rounded" />
+        </div>
+        <div>
+            <label class="block mb-1 text-sm font-medium">SEO Description</label>
+            <textarea wire:model="seo_description" class="w-full px-3 py-2 border rounded"></textarea>
+        </div>
+        <div>
+            <label class="block mb-1 text-sm font-medium">SEO Keywords</label>
+            <input type="text" wire:model="seo_keywords" class="w-full px-3 py-2 border rounded" />
+        </div>
+        <div class="text-right">
+            <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded">Save</button>
+        </div>
+    </form>
+</div>

--- a/resources/views/livewire/admin/jobs/edit.blade.php
+++ b/resources/views/livewire/admin/jobs/edit.blade.php
@@ -1,0 +1,71 @@
+<div class="max-w-3xl mx-auto bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
+    <form wire:submit.prevent="update" class="space-y-4">
+        <div>
+            <label class="block mb-1 text-sm font-medium">Title</label>
+            <input type="text" wire:model="title" class="w-full px-3 py-2 border rounded" />
+        </div>
+        <div>
+            <label class="block mb-1 text-sm font-medium">Slug</label>
+            <input type="text" wire:model="slug" class="w-full px-3 py-2 border rounded" />
+        </div>
+        <div>
+            <label class="block mb-1 text-sm font-medium">Category ID</label>
+            <input type="number" wire:model="category_id" class="w-full px-3 py-2 border rounded" />
+        </div>
+        <div>
+            <label class="block mb-1 text-sm font-medium">Company Name</label>
+            <input type="text" wire:model="company_name" class="w-full px-3 py-2 border rounded" />
+        </div>
+        <div>
+            <label class="block mb-1 text-sm font-medium">Summary</label>
+            <textarea wire:model="summary" class="w-full px-3 py-2 border rounded"></textarea>
+        </div>
+        <div>
+            <label class="block mb-1 text-sm font-medium">Description</label>
+            <textarea wire:model="description" class="w-full px-3 py-2 border rounded"></textarea>
+        </div>
+        <div class="grid grid-cols-2 gap-4">
+            <div>
+                <label class="block mb-1 text-sm font-medium">Deadline</label>
+                <input type="date" wire:model="deadline" class="w-full px-3 py-2 border rounded" />
+            </div>
+            <div>
+                <label class="block mb-1 text-sm font-medium">Posted At</label>
+                <input type="datetime-local" wire:model="posted_at" class="w-full px-3 py-2 border rounded" />
+            </div>
+        </div>
+        <div class="grid grid-cols-2 gap-4">
+            <div>
+                <label class="block mb-1 text-sm font-medium">Status</label>
+                <select wire:model="status" class="w-full px-3 py-2 border rounded">
+                    @foreach(\App\Enums\JobStatus::cases() as $status)
+                        <option value="{{ $status->value }}">{{ ucfirst($status->value) }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="flex items-center mt-6">
+                <input type="checkbox" wire:model="featured" id="featured" class="mr-2" />
+                <label for="featured" class="text-sm">Featured</label>
+            </div>
+        </div>
+        <div>
+            <label class="block mb-1 text-sm font-medium">Cover Image</label>
+            <input type="text" wire:model="cover_image" class="w-full px-3 py-2 border rounded" />
+        </div>
+        <div>
+            <label class="block mb-1 text-sm font-medium">SEO Title</label>
+            <input type="text" wire:model="seo_title" class="w-full px-3 py-2 border rounded" />
+        </div>
+        <div>
+            <label class="block mb-1 text-sm font-medium">SEO Description</label>
+            <textarea wire:model="seo_description" class="w-full px-3 py-2 border rounded"></textarea>
+        </div>
+        <div>
+            <label class="block mb-1 text-sm font-medium">SEO Keywords</label>
+            <input type="text" wire:model="seo_keywords" class="w-full px-3 py-2 border rounded" />
+        </div>
+        <div class="text-right">
+            <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded">Update</button>
+        </div>
+    </form>
+</div>

--- a/resources/views/livewire/admin/jobs/index.blade.php
+++ b/resources/views/livewire/admin/jobs/index.blade.php
@@ -1,0 +1,74 @@
+<div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+    <div class="flex flex-col sm:flex-row sm:justify-between gap-4 mb-4">
+        <input type="text" wire:model.live.debounce.300ms="search" placeholder="Search jobs..."
+               class="flex-1 px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
+        <a wire:navigate href="{{ route('admin.jobs.create') }}"
+           class="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700">New Job</a>
+    </div>
+
+    <div class="overflow-x-auto">
+        <table class="min-w-full text-sm divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-700">
+                <tr>
+                    <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">#</th>
+                    <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Title</th>
+                    <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Company</th>
+                    <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Status</th>
+                    <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Actions</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                @forelse($jobs as $job)
+                    <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+                        <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $job->id }}</td>
+                        <td class="px-4 py-2">{{ $job->title }}</td>
+                        <td class="px-4 py-2">{{ $job->company_name }}</td>
+                        <td class="px-4 py-2">{{ ucfirst($job->status->value) }}</td>
+                        <td class="px-4 py-2 space-x-2">
+                            <a wire:navigate href="{{ route('admin.jobs.edit', $job) }}" class="text-indigo-600 hover:text-indigo-800">Edit</a>
+                            <button type="button" onclick="confirmDelete({{ $job->id }})" class="text-red-600 hover:text-red-800">Delete</button>
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="5" class="px-4 py-6 text-center text-gray-500 dark:text-gray-400">No jobs found.</td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+    <div class="mt-4">{{ $jobs->links() }}</div>
+</div>
+
+@push('scripts')
+<script>
+    function confirmDelete(id) {
+        if (!window.Swal) return;
+        Swal.fire({
+            title: 'Delete this job?',
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonColor: '#d33',
+            cancelButtonColor: '#3085d6',
+            confirmButtonText: 'Yes, delete it!'
+        }).then((result) => {
+            if (result.isConfirmed) {
+                Livewire.dispatch('deleteJobConfirmed', { id: id });
+            }
+        });
+    }
+
+    window.addEventListener('jobDeleted', e => {
+        if (window.Swal) {
+            Swal.fire({
+                toast: true,
+                icon: 'success',
+                title: e.detail.message || 'Job deleted successfully.',
+                position: 'top-end',
+                showConfirmButton: false,
+                timer: 1500,
+            });
+        }
+    });
+</script>
+@endpush

--- a/resources/views/livewire/admin/partials/sidebar.blade.php
+++ b/resources/views/livewire/admin/partials/sidebar.blade.php
@@ -86,6 +86,11 @@
                 <x-heroicon-o-user-group class="w-5 h-5"/>
                 <span class="sidebar-text">Users</span>
             </a>
+            <a wire:navigate href="{{ route('admin.jobs.index') }}"
+               class="nav-link flex items-center gap-3 px-4 py-2.5 rounded-lg {{ request()->is('admin/jobs*') ? 'bg-indigo-50 dark:bg-gray-700 text-indigo-600 dark:text-indigo-400 font-semibold' : '' }}">
+                <x-heroicon-o-briefcase class="w-5 h-5"/>
+                <span class="sidebar-text">Jobs</span>
+            </a>
         @endif
     </nav>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,9 @@ use App\Livewire\Admin\Chapters\Create as ChapterCreate;
 use App\Livewire\Admin\Chapters\Edit as ChapterEdit;
 use App\Livewire\Admin\Tags\Index as TagIndex;
 use App\Livewire\Admin\Users\Index as UserIndex;
+use App\Livewire\Admin\Jobs\Index as JobIndex;
+use App\Livewire\Admin\Jobs\Create as JobCreate;
+use App\Livewire\Admin\Jobs\Edit as JobEdit;
 use App\Livewire\Teacher\Dashboard as TeacherDashboard;
 use App\Livewire\Student\Dashboard as StudentDashboard;
 use App\Livewire\Practice;
@@ -43,6 +46,11 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::get('/admin/chapters', ChapterIndex::class)->name('admin.chapters.index');
     Route::get('/admin/chapters/create', ChapterCreate::class)->name('admin.chapters.create');
     Route::get('/admin/chapters/{chapter}/edit', ChapterEdit::class)->name('admin.chapters.edit');
+
+    // Jobs
+    Route::get('/admin/jobs', JobIndex::class)->name('admin.jobs.index');
+    Route::get('/admin/jobs/create', JobCreate::class)->name('admin.jobs.create');
+    Route::get('/admin/jobs/{job}/edit', JobEdit::class)->name('admin.jobs.edit');
 
     // Settings
     Route::get('/admin/settings', Settings::class)->name('admin.settings');


### PR DESCRIPTION
## Summary
- add JobStatus enum and JobPost model with SEO fields
- create job post CRUD Livewire components and views
- register admin routes and sidebar link for job posts

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a8974eaf4883269c8c701c01f6ef20