### PR TITLE
Integrate Quill editor with image uploads and auto slug generation

### DIFF
--- a/app/Http/Controllers/ImageController.php
+++ b/app/Http/Controllers/ImageController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+class ImageController extends Controller
+{
+    public function store(Request $request)
+    {
+        $request->validate([
+            'image' => 'required|image|max:2048',
+        ]);
+
+        $path = $request->file('image')->store('uploads', 'public');
+
+        return response()->json([
+            'url' => Storage::url($path),
+        ]);
+    }
+}
+

--- a/app/Livewire/Admin/Jobs/Create.php
+++ b/app/Livewire/Admin/Jobs/Create.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Admin\Jobs;
 use Livewire\Component;
 use App\Models\JobPost;
 use App\Enums\JobStatus;
+use Illuminate\Support\Str;
 
 class Create extends Component
 {
@@ -16,12 +17,17 @@ class Create extends Component
     public $description;
     public $deadline;
     public $posted_at;
-    public $status = JobStatus::DRAFT;
+    public $status = JobStatus::DRAFT->value;
     public $featured = false;
     public $cover_image;
     public $seo_title;
     public $seo_description;
     public $seo_keywords;
+
+    public function updatedTitle($value)
+    {
+        $this->slug = Str::slug($value);
+    }
 
     public function save()
     {

--- a/app/Livewire/Admin/Jobs/Edit.php
+++ b/app/Livewire/Admin/Jobs/Edit.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Admin\Jobs;
 use Livewire\Component;
 use App\Models\JobPost;
 use App\Enums\JobStatus;
+use Illuminate\Support\Str;
 
 class Edit extends Component
 {
@@ -41,6 +42,11 @@ class Edit extends Component
         $this->seo_title = $job->seo_title;
         $this->seo_description = $job->seo_description;
         $this->seo_keywords = $job->seo_keywords;
+    }
+
+    public function updatedTitle($value)
+    {
+        $this->slug = Str::slug($value);
     }
 
     public function update()

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -18,6 +18,9 @@
 
     {{-- Livewire Styles --}}
     @livewireStyles
+
+    {{-- Extra Styles --}}
+    @stack('styles')
 </head>
 <body class="font-sans antialiased">
     <div class="min-h-screen flex bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200 antialiased">

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,7 @@ use App\Livewire\Admin\Jobs\Edit as JobEdit;
 use App\Livewire\Teacher\Dashboard as TeacherDashboard;
 use App\Livewire\Student\Dashboard as StudentDashboard;
 use App\Livewire\Practice;
+use App\Http\Controllers\ImageController;
 Route::view('/', 'frontend.landing')->name('landing');
 Route::view('/frontend', 'frontend.landing');
 
@@ -51,6 +52,9 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::get('/admin/jobs', JobIndex::class)->name('admin.jobs.index');
     Route::get('/admin/jobs/create', JobCreate::class)->name('admin.jobs.create');
     Route::get('/admin/jobs/{job}/edit', JobEdit::class)->name('admin.jobs.edit');
+
+    // Images
+    Route::post('/admin/images/upload', [ImageController::class, 'store'])->name('admin.images.upload');
 
     // Settings
     Route::get('/admin/settings', Settings::class)->name('admin.settings');


### PR DESCRIPTION
## Summary
- use Quill editor for job descriptions with image upload support
- auto-generate slugs from job titles and fix JobStatus casting
- add image upload controller and route

## Testing
- `composer test` *(fails: vendor autoload missing)*
- `composer install` *(fails: GitHub 403 requires token)*

------
https://chatgpt.com/codex/tasks/task_e_68a89e57b4d0832696e0c4537761c50e