### PR TITLE
Add media manager module

### DIFF
--- a/app/Livewire/Admin/Media/Index.php
+++ b/app/Livewire/Admin/Media/Index.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace App\Livewire\Admin\Media;
+
+use App\Models\Media;
+use Livewire\Component;
+use Livewire\WithFileUploads;
+use Livewire\WithPagination;
+use Illuminate\Support\Facades\Storage;
+
+class Index extends Component
+{
+    use WithPagination, WithFileUploads;
+
+    public $file;
+    public $name = '';
+    public $search = '';
+
+    public $editingId = null;
+    public $editingName = '';
+
+    public $replacingId = null;
+    public $replaceFile;
+
+    protected $listeners = [
+        'mediaDeleted' => '$refresh',
+        'deleteMediaConfirmed' => 'delete',
+    ];
+
+    public function updatingSearch(): void
+    {
+        $this->resetPage();
+    }
+
+    public function upload(): void
+    {
+        $this->validate([
+            'file' => 'required|file|max:10240',
+            'name' => 'nullable|string|max:255',
+        ]);
+
+        $path = $this->file->store('media', 'public');
+        $mime = $this->file->getMimeType();
+        $size = $this->file->getSize();
+        $dimensions = str_starts_with($mime, 'image/') ? getimagesize($this->file->getRealPath()) : null;
+
+        Media::create([
+            'name' => $this->name ?: $this->file->getClientOriginalName(),
+            'filename' => basename($path),
+            'mime_type' => $mime,
+            'path' => $path,
+            'size' => $size,
+            'width' => $dimensions[0] ?? null,
+            'height' => $dimensions[1] ?? null,
+            'created_by' => auth()->id(),
+        ]);
+
+        $this->reset(['file', 'name']);
+        $this->resetPage();
+        $this->dispatch('mediaUploaded', message: 'Media uploaded successfully.');
+    }
+
+    public function edit($id): void
+    {
+        $media = Media::findOrFail($id);
+        $this->editingId = $media->id;
+        $this->editingName = $media->name;
+    }
+
+    public function update(): void
+    {
+        $this->validate([
+            'editingName' => 'required|string|max:255',
+        ]);
+
+        Media::findOrFail($this->editingId)->update(['name' => $this->editingName]);
+
+        $this->editingId = null;
+        $this->editingName = '';
+        $this->dispatch('mediaUpdated', message: 'Media updated successfully.');
+    }
+
+    public function cancelEdit(): void
+    {
+        $this->editingId = null;
+        $this->editingName = '';
+    }
+
+    public function startReplace($id): void
+    {
+        $this->replacingId = $id;
+    }
+
+    public function replace(): void
+    {
+        $this->validate([
+            'replaceFile' => 'required|file|max:10240',
+        ]);
+
+        $media = Media::findOrFail($this->replacingId);
+        Storage::disk('public')->delete($media->path);
+
+        $path = $this->replaceFile->store('media', 'public');
+        $mime = $this->replaceFile->getMimeType();
+        $size = $this->replaceFile->getSize();
+        $dimensions = str_starts_with($mime, 'image/') ? getimagesize($this->replaceFile->getRealPath()) : null;
+
+        $media->update([
+            'filename' => basename($path),
+            'mime_type' => $mime,
+            'path' => $path,
+            'size' => $size,
+            'width' => $dimensions[0] ?? null,
+            'height' => $dimensions[1] ?? null,
+        ]);
+
+        $this->replacingId = null;
+        $this->replaceFile = null;
+        $this->dispatch('mediaReplaced', message: 'Media replaced successfully.');
+    }
+
+    public function cancelReplace(): void
+    {
+        $this->replacingId = null;
+        $this->replaceFile = null;
+    }
+
+    public function delete($id): void
+    {
+        $media = Media::findOrFail($id);
+        Storage::disk('public')->delete($media->path);
+        $media->delete();
+        $this->resetPage();
+        $this->dispatch('mediaDeleted', message: 'Media deleted successfully.');
+    }
+
+    public function render()
+    {
+        $mediaItems = Media::when($this->search, fn($q) =>
+                $q->where('name', 'like', '%'.$this->search.'%')
+            )
+            ->orderByDesc('created_at')
+            ->paginate(10);
+
+        return view('livewire.admin.media.index', [
+            'mediaItems' => $mediaItems,
+        ])->layout('layouts.admin', ['title' => 'Media Manager']);
+    }
+}
+

--- a/app/Models/Media.php
+++ b/app/Models/Media.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Media extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'filename',
+        'mime_type',
+        'path',
+        'size',
+        'width',
+        'height',
+        'created_by',
+    ];
+
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+}
+

--- a/database/migrations/2025_08_14_231803_create_media_table.php
+++ b/database/migrations/2025_08_14_231803_create_media_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('media', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->nullable();
+            $table->string('filename');
+            $table->string('mime_type');
+            $table->string('path');
+            $table->unsignedBigInteger('size')->nullable();
+            $table->unsignedInteger('width')->nullable();
+            $table->unsignedInteger('height')->nullable();
+            $table->foreignId('created_by')->constrained('users')->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('media');
+    }
+};
+

--- a/resources/views/livewire/admin/media/index.blade.php
+++ b/resources/views/livewire/admin/media/index.blade.php
@@ -1,0 +1,101 @@
+<div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+    <div class="flex flex-col sm:flex-row sm:justify-between gap-4 mb-4">
+        <div class="flex-1 flex flex-col sm:flex-row gap-2">
+            <input type="file" wire:model="file" class="flex-1" />
+            <input type="text" wire:model="name" placeholder="Name" class="flex-1 px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
+            <button wire:click="upload" class="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500">Upload</button>
+        </div>
+        <input type="text" wire:model.live.debounce.300ms="search" placeholder="Search..." class="px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
+    </div>
+
+    <div class="overflow-x-auto">
+        <table class="min-w-full text-sm divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-700">
+            <tr>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">#</th>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Name</th>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Mime</th>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Size</th>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Actions</th>
+            </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+            @forelse($mediaItems as $media)
+                <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+                    <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $media->id }}</td>
+                    <td class="px-4 py-2">
+                        @if($editingId === $media->id)
+                            <form wire:submit.prevent="update" class="flex w-full gap-2">
+                                <input type="text" wire:model="editingName" class="flex-1 px-2 py-1 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
+                                <button type="submit" class="px-3 py-1 bg-indigo-600 text-white rounded-md hover:bg-indigo-700">Save</button>
+                                <button type="button" wire:click="cancelEdit" class="px-3 py-1 bg-gray-200 rounded-md hover:bg-gray-300 dark:bg-gray-600 dark:hover:bg-gray-500 dark:text-gray-200">Cancel</button>
+                            </form>
+                        @else
+                            <span class="text-gray-700 dark:text-gray-300">{{ $media->name }}</span>
+                        @endif
+                    </td>
+                    <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $media->mime_type }}</td>
+                    <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ number_format($media->size / 1024, 2) }} KB</td>
+                    <td class="px-4 py-2 space-x-2">
+                        @if($replacingId === $media->id)
+                            <form wire:submit.prevent="replace" class="flex gap-2">
+                                <input type="file" wire:model="replaceFile" class="flex-1" />
+                                <button type="submit" class="px-3 py-1 bg-indigo-600 text-white rounded-md hover:bg-indigo-700">Save</button>
+                                <button type="button" wire:click="cancelReplace" class="px-3 py-1 bg-gray-200 rounded-md hover:bg-gray-300 dark:bg-gray-600 dark:hover:bg-gray-500 dark:text-gray-200">Cancel</button>
+                            </form>
+                        @else
+                            <button wire:click="edit({{ $media->id }})" class="text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300">Edit</button>
+                            <button wire:click="startReplace({{ $media->id }})" class="text-yellow-600 hover:text-yellow-800 dark:text-yellow-400 dark:hover:text-yellow-300">Replace</button>
+                            <button type="button" onclick="confirmDelete({{ $media->id }})" class="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300">Delete</button>
+                        @endif
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="5" class="px-4 py-6 text-center text-gray-500 dark:text-gray-400">No media found.</td>
+                </tr>
+            @endforelse
+            </tbody>
+        </table>
+    </div>
+    <div class="mt-4">{{ $mediaItems->links() }}</div>
+</div>
+
+@push('scripts')
+<script>
+    function showToast(message) {
+        if (!window.Swal) return;
+        Swal.fire({
+            toast: true,
+            icon: 'success',
+            title: message,
+            position: 'top-end',
+            showConfirmButton: false,
+            timer: 1500,
+        });
+    }
+
+    function confirmDelete(id) {
+        if (!window.Swal) return;
+        Swal.fire({
+            title: 'Delete this media?',
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonColor: '#d33',
+            cancelButtonColor: '#3085d6',
+            confirmButtonText: 'Yes, delete it!'
+        }).then((result) => {
+            if (result.isConfirmed) {
+                Livewire.dispatch('deleteMediaConfirmed', { id: id });
+            }
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        window.addEventListener('mediaUploaded', e => showToast(e.detail.message));
+        window.addEventListener('mediaUpdated', e => showToast(e.detail.message));
+        window.addEventListener('mediaReplaced', e => showToast(e.detail.message));
+        window.addEventListener('mediaDeleted', e => showToast(e.detail.message));
+    });
+</script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,7 @@ use App\Livewire\Admin\Users\Index as UserIndex;
 use App\Livewire\Admin\Jobs\Index as JobIndex;
 use App\Livewire\Admin\Jobs\Create as JobCreate;
 use App\Livewire\Admin\Jobs\Edit as JobEdit;
+use App\Livewire\Admin\Media\Index as MediaIndex;
 use App\Livewire\Teacher\Dashboard as TeacherDashboard;
 use App\Livewire\Student\Dashboard as StudentDashboard;
 use App\Livewire\Practice;
@@ -52,6 +53,8 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::get('/admin/jobs', JobIndex::class)->name('admin.jobs.index');
     Route::get('/admin/jobs/create', JobCreate::class)->name('admin.jobs.create');
     Route::get('/admin/jobs/{job}/edit', JobEdit::class)->name('admin.jobs.edit');
+    // Media
+    Route::get('/admin/media', MediaIndex::class)->name('admin.media.index');
 
     // Images
     Route::post('/admin/images/upload', [ImageController::class, 'store'])->name('admin.images.upload');


### PR DESCRIPTION
## Summary
- add media table & model for storing uploaded file metadata
- implement Livewire admin media manager for upload, rename, replace, delete
- expose media manager via admin route and blade view

## Testing
- `php artisan test` *(fails: missing vendor/autoload.php; composer install requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a81d4ae883268e0292ea438dc599