### PR TITLE
Add Dropzone media uploads with sidebar access

### DIFF
--- a/app/Http/Controllers/MediaController.php
+++ b/app/Http/Controllers/MediaController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Media;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+class MediaController extends Controller
+{
+    public function store(Request $request)
+    {
+        $request->validate([
+            'file' => 'required|file|max:10240',
+        ]);
+
+        $file = $request->file('file');
+        $path = $file->store('media', 'public');
+        $mime = $file->getMimeType();
+        $size = $file->getSize();
+        $dimensions = str_starts_with($mime, 'image/') ? getimagesize($file->getRealPath()) : null;
+
+        $media = Media::create([
+            'name' => $file->getClientOriginalName(),
+            'filename' => basename($path),
+            'mime_type' => $mime,
+            'path' => $path,
+            'size' => $size,
+            'width' => $dimensions[0] ?? null,
+            'height' => $dimensions[1] ?? null,
+            'created_by' => $request->user()->id,
+        ]);
+
+        return response()->json([
+            'message' => 'Media uploaded successfully.',
+            'media' => $media,
+        ]);
+    }
+}
+

--- a/app/Livewire/Admin/Media/Index.php
+++ b/app/Livewire/Admin/Media/Index.php
@@ -12,8 +12,6 @@ class Index extends Component
 {
     use WithPagination, WithFileUploads;
 
-    public $file;
-    public $name = '';
     public $search = '';
 
     public $editingId = null;
@@ -24,6 +22,7 @@ class Index extends Component
 
     protected $listeners = [
         'mediaDeleted' => '$refresh',
+        'refreshMedia' => '$refresh',
         'deleteMediaConfirmed' => 'delete',
     ];
 
@@ -32,33 +31,7 @@ class Index extends Component
         $this->resetPage();
     }
 
-    public function upload(): void
-    {
-        $this->validate([
-            'file' => 'required|file|max:10240',
-            'name' => 'nullable|string|max:255',
-        ]);
 
-        $path = $this->file->store('media', 'public');
-        $mime = $this->file->getMimeType();
-        $size = $this->file->getSize();
-        $dimensions = str_starts_with($mime, 'image/') ? getimagesize($this->file->getRealPath()) : null;
-
-        Media::create([
-            'name' => $this->name ?: $this->file->getClientOriginalName(),
-            'filename' => basename($path),
-            'mime_type' => $mime,
-            'path' => $path,
-            'size' => $size,
-            'width' => $dimensions[0] ?? null,
-            'height' => $dimensions[1] ?? null,
-            'created_by' => auth()->id(),
-        ]);
-
-        $this->reset(['file', 'name']);
-        $this->resetPage();
-        $this->dispatch('mediaUploaded', message: 'Media uploaded successfully.');
-    }
 
     public function edit($id): void
     {

--- a/resources/views/livewire/admin/media/index.blade.php
+++ b/resources/views/livewire/admin/media/index.blade.php
@@ -1,10 +1,12 @@
+@push('styles')
+<link rel="stylesheet" href="https://unpkg.com/dropzone@6.0.0/dist/dropzone.css" />
+@endpush
+
 <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
-    <div class="flex flex-col sm:flex-row sm:justify-between gap-4 mb-4">
-        <div class="flex-1 flex flex-col sm:flex-row gap-2">
-            <input type="file" wire:model="file" class="flex-1" />
-            <input type="text" wire:model="name" placeholder="Name" class="flex-1 px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
-            <button wire:click="upload" class="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500">Upload</button>
-        </div>
+    <div class="mb-4">
+        <form action="{{ route('admin.media.upload') }}" id="media-dropzone" class="dropzone border-2 border-dashed rounded-md"></form>
+    </div>
+    <div class="mb-4">
         <input type="text" wire:model.live.debounce.300ms="search" placeholder="Search..." class="px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
     </div>
 
@@ -62,6 +64,7 @@
 </div>
 
 @push('scripts')
+<script src="https://unpkg.com/dropzone@6.0.0/dist/dropzone-min.js"></script>
 <script>
     function showToast(message) {
         if (!window.Swal) return;
@@ -92,10 +95,22 @@
     }
 
     document.addEventListener('DOMContentLoaded', () => {
-        window.addEventListener('mediaUploaded', e => showToast(e.detail.message));
         window.addEventListener('mediaUpdated', e => showToast(e.detail.message));
         window.addEventListener('mediaReplaced', e => showToast(e.detail.message));
         window.addEventListener('mediaDeleted', e => showToast(e.detail.message));
+
+        Dropzone.autoDiscover = false;
+        const dz = new Dropzone('#media-dropzone', {
+            url: '{{ route('admin.media.upload') }}',
+            headers: { 'X-CSRF-TOKEN': '{{ csrf_token() }}' },
+            maxFilesize: 10,
+        });
+
+        dz.on('success', (file, response) => {
+            showToast(response.message);
+            Livewire.dispatch('refreshMedia');
+            dz.removeFile(file);
+        });
     });
 </script>
 @endpush

--- a/resources/views/livewire/admin/partials/sidebar.blade.php
+++ b/resources/views/livewire/admin/partials/sidebar.blade.php
@@ -91,6 +91,11 @@
                 <x-heroicon-o-briefcase class="w-5 h-5"/>
                 <span class="sidebar-text">Jobs</span>
             </a>
+            <a wire:navigate href="{{ route('admin.media.index') }}"
+               class="nav-link flex items-center gap-3 px-4 py-2.5 rounded-lg {{ request()->is('admin/media*') ? 'bg-indigo-50 dark:bg-gray-700 text-indigo-600 dark:text-indigo-400 font-semibold' : '' }}">
+                <x-heroicon-o-photo class="w-5 h-5"/>
+                <span class="sidebar-text">Media</span>
+            </a>
         @endif
     </nav>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,7 @@ use App\Livewire\Teacher\Dashboard as TeacherDashboard;
 use App\Livewire\Student\Dashboard as StudentDashboard;
 use App\Livewire\Practice;
 use App\Http\Controllers\ImageController;
+use App\Http\Controllers\MediaController;
 Route::view('/', 'frontend.landing')->name('landing');
 Route::view('/frontend', 'frontend.landing');
 
@@ -55,6 +56,7 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::get('/admin/jobs/{job}/edit', JobEdit::class)->name('admin.jobs.edit');
     // Media
     Route::get('/admin/media', MediaIndex::class)->name('admin.media.index');
+    Route::post('/admin/media/upload', [MediaController::class, 'store'])->name('admin.media.upload');
 
     // Images
     Route::post('/admin/images/upload', [ImageController::class, 'store'])->name('admin.images.upload');


### PR DESCRIPTION
## Summary
- integrate Dropzone-based media uploader that stores metadata
- add Media section to admin sidebar

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: requires GitHub token, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a8acc136888326a84104b7a3e35329