### PR TITLE
feat: add modal media uploader with URL support

### DIFF
--- a/app/Http/Controllers/MediaController.php
+++ b/app/Http/Controllers/MediaController.php
@@ -4,24 +4,46 @@ namespace App\Http\Controllers;
 
 use App\Models\Media;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 
 class MediaController extends Controller
 {
     public function store(Request $request)
     {
         $request->validate([
-            'file' => 'required|file|max:10240',
+            'file' => 'nullable|file|max:10240',
+            'url' => 'nullable|url',
         ]);
 
-        $file = $request->file('file');
-        $path = $file->store('media', 'public');
-        $mime = $file->getMimeType();
-        $size = $file->getSize();
-        $dimensions = str_starts_with($mime, 'image/') ? getimagesize($file->getRealPath()) : null;
+        if ($request->hasFile('file')) {
+            $file = $request->file('file');
+            $path = $file->store('media', 'public');
+            $mime = $file->getMimeType();
+            $size = $file->getSize();
+            $dimensions = str_starts_with($mime, 'image/') ? getimagesize($file->getRealPath()) : null;
+            $originalName = $file->getClientOriginalName();
+        } elseif ($request->filled('url')) {
+            $response = Http::get($request->input('url'));
+            if (! $response->successful()) {
+                return response()->json(['message' => 'Unable to download file.'], 422);
+            }
+
+            $content = $response->body();
+            $mime = $response->header('Content-Type', 'application/octet-stream');
+            $size = strlen($content);
+            $filename = basename(parse_url($request->input('url'), PHP_URL_PATH)) ?: 'file';
+            $path = 'media/' . Str::random(40) . '-' . $filename;
+            Storage::disk('public')->put($path, $content);
+            $dimensions = str_starts_with($mime, 'image/') ? getimagesizefromstring($content) : null;
+            $originalName = $filename;
+        } else {
+            return response()->json(['message' => 'No file or url provided.'], 422);
+        }
 
         $media = Media::create([
-            'name' => $file->getClientOriginalName(),
+            'name' => $originalName,
             'filename' => basename($path),
             'mime_type' => $mime,
             'path' => $path,


### PR DESCRIPTION
## Summary
- add URL-based upload handling in MediaController
- introduce modal uploader with Dropzone and link upload
- show media details via modal when clicking a name

## Testing
- `composer test` *(fails: require vendor; composer install requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b11bf93c8326ab71f0d3b223fcc9