### PR TITLE
Wrap admin media Livewire component in a single root element

### DIFF
--- a/resources/views/livewire/admin/media/index.blade.php
+++ b/resources/views/livewire/admin/media/index.blade.php
@@ -2,88 +2,90 @@
 <link rel="stylesheet" href="https://unpkg.com/dropzone@6.0.0/dist/dropzone.css" />
 @endpush
 
-<div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
-    <div class="mb-4 flex justify-end">
-        <button id="open-uploader" class="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700">Add Media</button>
-    </div>
-    <div class="mb-4">
-        <input type="text" wire:model.live.debounce.300ms="search" placeholder="Search..." class="px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
-    </div>
-
-    <div class="overflow-x-auto">
-        <table class="min-w-full text-sm divide-y divide-gray-200 dark:divide-gray-700">
-            <thead class="bg-gray-50 dark:bg-gray-700">
-            <tr>
-                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">#</th>
-                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Name</th>
-                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Mime</th>
-                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Size</th>
-                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Actions</th>
-            </tr>
-            </thead>
-            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
-            @forelse($mediaItems as $media)
-                <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
-                    <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $media->id }}</td>
-                    <td class="px-4 py-2">
-                        @if($editingId === $media->id)
-                            <form wire:submit.prevent="update" class="flex w-full gap-2">
-                                <input type="text" wire:model="editingName" class="flex-1 px-2 py-1 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
-                                <button type="submit" class="px-3 py-1 bg-indigo-600 text-white rounded-md hover:bg-indigo-700">Save</button>
-                                <button type="button" wire:click="cancelEdit" class="px-3 py-1 bg-gray-200 rounded-md hover:bg-gray-300 dark:bg-gray-600 dark:hover:bg-gray-500 dark:text-gray-200">Cancel</button>
-                            </form>
-                        @else
-                            @php
-                                $details = [
-                                    'name' => $media->name,
-                                    'mime' => $media->mime_type,
-                                    'size' => $media->size,
-                                    'width' => $media->width,
-                                    'height' => $media->height,
-                                    'url' => Storage::url($media->path),
-                                ];
-                            @endphp
-                            <button type="button" onclick='showDetails(@json($details))' class="text-indigo-600 hover:underline dark:text-indigo-400">{{ $media->name }}</button>
-                        @endif
-                    </td>
-                    <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $media->mime_type }}</td>
-                    <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ number_format($media->size / 1024, 2) }} KB</td>
-                    <td class="px-4 py-2 space-x-2">
-                        @if($replacingId === $media->id)
-                            <form wire:submit.prevent="replace" class="flex gap-2">
-                                <input type="file" wire:model="replaceFile" class="flex-1" />
-                                <button type="submit" class="px-3 py-1 bg-indigo-600 text-white rounded-md hover:bg-indigo-700">Save</button>
-                                <button type="button" wire:click="cancelReplace" class="px-3 py-1 bg-gray-200 rounded-md hover:bg-gray-300 dark:bg-gray-600 dark:hover:bg-gray-500 dark:text-gray-200">Cancel</button>
-                            </form>
-                        @else
-                            <button wire:click="edit({{ $media->id }})" class="text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300">Edit</button>
-                            <button wire:click="startReplace({{ $media->id }})" class="text-yellow-600 hover:text-yellow-800 dark:text-yellow-400 dark:hover:text-yellow-300">Replace</button>
-                            <button type="button" onclick="confirmDelete({{ $media->id }})" class="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300">Delete</button>
-                        @endif
-                    </td>
-                </tr>
-            @empty
-                <tr>
-                    <td colspan="5" class="px-4 py-6 text-center text-gray-500 dark:text-gray-400">No media found.</td>
-                </tr>
-            @endforelse
-            </tbody>
-        </table>
-    </div>
-    <div class="mt-4">{{ $mediaItems->links() }}</div>
-</div>
-
-<div id="upload-modal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
-    <div class="bg-white dark:bg-gray-800 p-6 rounded-md w-full max-w-lg">
+<div>
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+        <div class="mb-4 flex justify-end">
+            <button id="open-uploader" class="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700">Add Media</button>
+        </div>
         <div class="mb-4">
-            <form action="{{ route('admin.media.upload') }}" id="media-dropzone" class="dropzone border-2 border-dashed rounded-md"></form>
+            <input type="text" wire:model.live.debounce.300ms="search" placeholder="Search..." class="px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
         </div>
-        <div class="flex mb-4">
-            <input type="text" id="media-url" placeholder="Media URL" class="flex-1 px-3 py-2 border border-gray-300 rounded-md dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
-            <button id="upload-url-btn" class="ml-2 px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700">Upload</button>
+
+        <div class="overflow-x-auto">
+            <table class="min-w-full text-sm divide-y divide-gray-200 dark:divide-gray-700">
+                <thead class="bg-gray-50 dark:bg-gray-700">
+                <tr>
+                    <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">#</th>
+                    <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Name</th>
+                    <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Mime</th>
+                    <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Size</th>
+                    <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Actions</th>
+                </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                @forelse($mediaItems as $media)
+                    <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+                        <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $media->id }}</td>
+                        <td class="px-4 py-2">
+                            @if($editingId === $media->id)
+                                <form wire:submit.prevent="update" class="flex w-full gap-2">
+                                    <input type="text" wire:model="editingName" class="flex-1 px-2 py-1 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
+                                    <button type="submit" class="px-3 py-1 bg-indigo-600 text-white rounded-md hover:bg-indigo-700">Save</button>
+                                    <button type="button" wire:click="cancelEdit" class="px-3 py-1 bg-gray-200 rounded-md hover:bg-gray-300 dark:bg-gray-600 dark:hover:bg-gray-500 dark:text-gray-200">Cancel</button>
+                                </form>
+                            @else
+                                @php
+                                    $details = [
+                                        'name' => $media->name,
+                                        'mime' => $media->mime_type,
+                                        'size' => $media->size,
+                                        'width' => $media->width,
+                                        'height' => $media->height,
+                                        'url' => Storage::url($media->path),
+                                    ];
+                                @endphp
+                                <button type="button" onclick='showDetails(@json($details))' class="text-indigo-600 hover:underline dark:text-indigo-400">{{ $media->name }}</button>
+                            @endif
+                        </td>
+                        <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $media->mime_type }}</td>
+                        <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ number_format($media->size / 1024, 2) }} KB</td>
+                        <td class="px-4 py-2 space-x-2">
+                            @if($replacingId === $media->id)
+                                <form wire:submit.prevent="replace" class="flex gap-2">
+                                    <input type="file" wire:model="replaceFile" class="flex-1" />
+                                    <button type="submit" class="px-3 py-1 bg-indigo-600 text-white rounded-md hover:bg-indigo-700">Save</button>
+                                    <button type="button" wire:click="cancelReplace" class="px-3 py-1 bg-gray-200 rounded-md hover:bg-gray-300 dark:bg-gray-600 dark:hover:bg-gray-500 dark:text-gray-200">Cancel</button>
+                                </form>
+                            @else
+                                <button wire:click="edit({{ $media->id }})" class="text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300">Edit</button>
+                                <button wire:click="startReplace({{ $media->id }})" class="text-yellow-600 hover:text-yellow-800 dark:text-yellow-400 dark:hover:text-yellow-300">Replace</button>
+                                <button type="button" onclick="confirmDelete({{ $media->id }})" class="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300">Delete</button>
+                            @endif
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="5" class="px-4 py-6 text-center text-gray-500 dark:text-gray-400">No media found.</td>
+                    </tr>
+                @endforelse
+                </tbody>
+            </table>
         </div>
-        <div class="text-right">
-            <button id="close-uploader" class="px-3 py-1 bg-gray-200 rounded-md dark:bg-gray-600 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-500">Close</button>
+        <div class="mt-4">{{ $mediaItems->links() }}</div>
+    </div>
+
+    <div id="upload-modal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
+        <div class="bg-white dark:bg-gray-800 p-6 rounded-md w-full max-w-lg">
+            <div class="mb-4">
+                <form action="{{ route('admin.media.upload') }}" id="media-dropzone" class="dropzone border-2 border-dashed rounded-md"></form>
+            </div>
+            <div class="flex mb-4">
+                <input type="text" id="media-url" placeholder="Media URL" class="flex-1 px-3 py-2 border border-gray-300 rounded-md dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
+                <button id="upload-url-btn" class="ml-2 px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700">Upload</button>
+            </div>
+            <div class="text-right">
+                <button id="close-uploader" class="px-3 py-1 bg-gray-200 rounded-md dark:bg-gray-600 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-500">Close</button>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- wrap admin media component markup in a single root `<div>` so Livewire detects only one root element

## Testing
- `composer test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: CONNECT tunnel failed, response 403, GitHub token required)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b53e26008326b730306c2a9b5434