### PR TITLE
Add chat option to teacher dashboard

### DIFF
--- a/app/Livewire/Teacher/Chat.php
+++ b/app/Livewire/Teacher/Chat.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Livewire\Teacher;
+
+use App\Livewire\Admin\Chat as AdminChat;
+
+class Chat extends AdminChat
+{
+    // Inherit all chat functionality from the admin component
+}
+

--- a/resources/views/livewire/teacher/dashboard.blade.php
+++ b/resources/views/livewire/teacher/dashboard.blade.php
@@ -12,6 +12,8 @@
         <h2 class="text-xl font-semibold mb-2">Questions by Subject</h2>
         <div id="subjectChart" class="h-64"></div>
     </div>
+
+    <livewire:teacher.chat />
 </div>
 
 @push('scripts')


### PR DESCRIPTION
## Summary
- Reuse admin chat component for teachers
- Embed chat widget in teacher dashboard

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa74fc5d008326b5e0775dc3319c12