### PR TITLE
Enable global chat box

### DIFF
--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -29,9 +29,9 @@
         {{-- Mobile Sidebar Overlay --}}
         <div id="sidebar-overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden z-40 md:hidden"></div>
     </div>
-    @if(auth()->user()->isTeacher() || auth()->user()->isStudent())
+    @auth
         <livewire:chat-popup />
-    @endif
+    @endauth
     @livewireScripts
 
     <script>

--- a/resources/views/layouts/panel.blade.php
+++ b/resources/views/layouts/panel.blade.php
@@ -32,6 +32,9 @@
 </div>
 
 {{-- ✅ Scripts --}}
+@auth
+    <livewire:chat-popup />
+@endauth
 <script>
     // --- Sidebar Collapse / Expand ---
     const sidebar = document.getElementById('sidebar');

--- a/resources/views/livewire/chat-popup.blade.php
+++ b/resources/views/livewire/chat-popup.blade.php
@@ -13,7 +13,7 @@
             <span class="font-semibold text-gray-800 dark:text-gray-100">Chat with {{ $admin->name }}</span>
             <button @click="open = false" class="text-gray-500">&times;</button>
         </div>
-        <div id="chatMessages" class="flex-1 p-2 overflow-y-auto space-y-2">
+        <div id="chatMessages" class="p-2 overflow-y-auto space-y-2 h-64">
             @forelse($messages as $msg)
                 <div class="flex {{ $msg->user_id === auth()->id() ? 'justify-end' : 'justify-start' }}">
                     <div class="px-3 py-2 rounded-lg max-w-[70%] text-sm {{ $msg->user_id === auth()->id() ? 'bg-indigo-600 text-white' : 'bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-100' }}">


### PR DESCRIPTION
## Summary
- Show chat popup on all authenticated layouts
- Limit chat popup message area height with scroll

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2d13e2888326bd2888e8b7b5bd08