### PR TITLE
Show generic chat title until admin joins

### DIFF
--- a/app/Livewire/ChatPopup.php
+++ b/app/Livewire/ChatPopup.php
@@ -127,10 +127,18 @@ class ChatPopup extends Component
             $this->markAsRead();
         }
 
+        $messages = $this->messages;
+        $adminMessage = $messages->first(function ($msg) {
+            return $msg->user && $msg->user->role === Role::ADMIN;
+        });
+        $chatTitle = $adminMessage
+            ? 'Chat with ' . $adminMessage->user->name
+            : 'Chat with Support Team';
+
         return view('livewire.chat-popup', [
-            'messages' => $this->messages,
+            'messages' => $messages,
             'unreadCount' => $this->unreadCount,
-            'admin' => User::where('role', Role::ADMIN)->first(),
+            'chatTitle' => $chatTitle,
         ]);
     }
 }

--- a/resources/views/livewire/chat-popup.blade.php
+++ b/resources/views/livewire/chat-popup.blade.php
@@ -10,7 +10,7 @@
 
     <div x-show="open" x-transition class="mt-2 w-80 bg-white dark:bg-gray-800 rounded-lg shadow-xl flex flex-col">
         <div class="flex items-center justify-between p-2 border-b border-gray-200 dark:border-gray-700">
-            <span class="font-semibold text-gray-800 dark:text-gray-100">Chat with {{ $admin->name }}</span>
+            <span class="font-semibold text-gray-800 dark:text-gray-100">{{ $chatTitle }}</span>
             <button @click="open = false" class="text-gray-500">&times;</button>
         </div>
         <div id="chatMessages" class="p-2 overflow-y-auto space-y-2 h-64">


### PR DESCRIPTION
## Summary
- Display a generic "Chat with Support Team" heading until an admin participates
- Update chat view to use dynamic title based on participating admin

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: CONNECT tunnel failed to api.github.com)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2f86c1f483269e359059ec92ce28