### PR TITLE
Fix admin Chat component class name conflict

### DIFF
--- a/app/Livewire/Admin/Chat.php
+++ b/app/Livewire/Admin/Chat.php
@@ -3,7 +3,7 @@
 namespace App\Livewire\Admin;
 
 use App\Events\ChatAssigned;
-use App\Models\Chat;
+use App\Models\Chat as ChatModel;
 use App\Models\ChatMessage;
 use App\Models\User;
 use App\Models\Setting;
@@ -29,7 +29,7 @@ class Chat extends Component
 
     public function updatedRecipientId($value): void
     {
-        $chat = Chat::firstOrCreate(['user_id' => $value]);
+        $chat = ChatModel::firstOrCreate(['user_id' => $value]);
         if ($chat->assigned_admin_id !== Auth::id()) {
             $chat->assigned_admin_id = Auth::id();
             $chat->save();


### PR DESCRIPTION
## Summary
- Prevent class name collision in admin Chat component by aliasing the Chat model

## Testing
- ⚠️ `composer test` *(failed: missing vendor autoload)*
- ⚠️ `composer install` *(failed: GitHub 403 when downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ab39f09f0c8326a2473d60685ba8d0