### PR TITLE
Fix real-time chat assignment for student view

### DIFF
--- a/app/Livewire/ChatPopup.php
+++ b/app/Livewire/ChatPopup.php
@@ -38,6 +38,12 @@ class ChatPopup extends Component
 
     protected function getAdminId(): ?int
     {
+        if (!$this->assignedAdminId) {
+            $chat = Chat::where('user_id', Auth::id())->first();
+            if ($chat) {
+                $this->assignedAdminId = $chat->assigned_admin_id;
+            }
+        }
         return $this->assignedAdminId;
     }
 

--- a/tests/Feature/ChatPopupTest.php
+++ b/tests/Feature/ChatPopupTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature;
 
 use App\Enums\Role;
 use App\Livewire\ChatPopup;
+use App\Models\Chat;
+use App\Models\ChatMessage;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
@@ -33,6 +35,32 @@ class ChatPopupTest extends TestCase
             'recipient_id' => $admin->id,
             'message' => 'Hello Admin',
         ]);
+    }
+
+    public function test_student_sees_admin_reply_without_reload(): void
+    {
+        $admin = User::factory()->create(['role' => Role::ADMIN]);
+        $student = User::factory()->create(['role' => Role::TEACHER]);
+
+        $this->actingAs($student);
+
+        $component = Livewire::test(ChatPopup::class);
+        $component->set('message', 'Hi')->call('send');
+
+        Artisan::call('chat:flush');
+
+        Chat::where('user_id', $student->id)->update(['assigned_admin_id' => $admin->id]);
+        ChatMessage::where('user_id', $student->id)->update(['recipient_id' => $admin->id]);
+        ChatMessage::create([
+            'user_id' => $admin->id,
+            'recipient_id' => $student->id,
+            'message' => 'Hello',
+            'created_at' => now(),
+        ]);
+
+        $component->call('$refresh')
+            ->assertSee('Hi')
+            ->assertSee('Hello');
     }
 }
 


### PR DESCRIPTION
## Summary
- Ensure chat popup refresh checks latest admin assignment
- Add test verifying student sees admin replies without reload

## Testing
- `composer test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: curl error 56, CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6fbff9608326aaea9c3b3d7c9398