### PR TITLE
Add notification sound for new chat messages

### DIFF
--- a/resources/views/livewire/chat-popup.blade.php
+++ b/resources/views/livewire/chat-popup.blade.php
@@ -46,6 +46,18 @@
         Livewire.on('chat-message-sent', () => {
             scroll();
         });
+        Livewire.on('chat-message-received', () => {
+            scroll();
+            const ctx = new (window.AudioContext || window.webkitAudioContext)();
+            const oscillator = ctx.createOscillator();
+            const gain = ctx.createGain();
+            oscillator.type = 'sine';
+            oscillator.frequency.value = 1000;
+            oscillator.connect(gain);
+            gain.connect(ctx.destination);
+            oscillator.start();
+            oscillator.stop(ctx.currentTime + 0.2);
+        });
     });
 </script>
 @endpush


### PR DESCRIPTION
## Summary
- dispatch chat-message-received when a new incoming message is detected
- play a short beep in the chat popup when chat-message-received event fires

## Testing
- `php artisan test` *(fails: require vendor autoload)*
- `composer install` *(fails: GitHub token required)*

------
https://chatgpt.com/codex/tasks/task_e_68ab79b28298832689e36b82e40aa437