### PR TITLE
feat(chat): add real-time messaging enhancements

### DIFF
--- a/app/Events/MessageSent.php
+++ b/app/Events/MessageSent.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class MessageSent implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public array $message;
+
+    public function __construct(array $message)
+    {
+        $this->message = $message;
+    }
+
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('chat.' . $this->message['recipient_id']),
+            new PrivateChannel('chat.' . $this->message['user_id']),
+        ];
+    }
+
+    public function broadcastWith(): array
+    {
+        return ['message' => $this->message];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'MessageSent';
+    }
+}
+

--- a/app/Events/UserTyping.php
+++ b/app/Events/UserTyping.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class UserTyping implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public int $from;
+    public int $to;
+
+    public function __construct(int $from, int $to)
+    {
+        $this->from = $from;
+        $this->to = $to;
+    }
+
+    public function broadcastOn(): array
+    {
+        return [new PrivateChannel('chat.' . $this->to)];
+    }
+
+    public function broadcastWith(): array
+    {
+        return ['user_id' => $this->from];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'UserTyping';
+    }
+}
+

--- a/app/Models/ChatMessage.php
+++ b/app/Models/ChatMessage.php
@@ -13,11 +13,13 @@ class ChatMessage extends Model
         'user_id',
         'recipient_id',
         'message',
-        'read_at',
+        'delivered_at',
+        'seen_at',
     ];
 
     protected $casts = [
-        'read_at' => 'datetime',
+        'delivered_at' => 'datetime',
+        'seen_at' => 'datetime',
     ];
 
     public function user()

--- a/database/migrations/2025_08_14_231805_add_read_at_to_chat_messages_table.php
+++ b/database/migrations/2025_08_14_231805_add_read_at_to_chat_messages_table.php
@@ -9,14 +9,15 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('chat_messages', function (Blueprint $table) {
-            $table->timestamp('read_at')->nullable()->after('message');
+            $table->timestamp('delivered_at')->nullable()->after('message');
+            $table->timestamp('seen_at')->nullable()->after('delivered_at');
         });
     }
 
     public function down(): void
     {
         Schema::table('chat_messages', function (Blueprint $table) {
-            $table->dropColumn('read_at');
+            $table->dropColumn(['delivered_at', 'seen_at']);
         });
     }
 };

--- a/resources/views/livewire/admin/chat.blade.php
+++ b/resources/views/livewire/admin/chat.blade.php
@@ -41,7 +41,18 @@
                         @endif
                         <div class="max-w-xs px-3 py-2 rounded-lg text-sm {{ $msg->user_id === auth()->id() ? 'bg-indigo-600 text-white' : 'bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-100' }}">
                             <div>{{ $msg->message }}</div>
-                            <div class="text-[10px] text-right mt-1 opacity-70">{{ $msg->created_at->format('H:i') }}</div>
+                            <div class="text-[10px] text-right mt-1 opacity-70">
+                                {{ $msg->created_at->format('H:i') }}
+                                @if($msg->user_id === auth()->id())
+                                    @if($msg->seen_at)
+                                        <span>- Read</span>
+                                    @elseif($msg->delivered_at)
+                                        <span>- Delivered</span>
+                                    @else
+                                        <span>- Sent</span>
+                                    @endif
+                                @endif
+                            </div>
                         </div>
                         @if($msg->user_id === auth()->id())
                             @if (auth()->user()->avatar_url)
@@ -54,6 +65,9 @@
                 @empty
                     <div class="text-sm text-gray-500">No messages</div>
                 @endforelse
+                @if($this->isTyping)
+                    <div class="text-sm text-gray-500">Typing...</div>
+                @endif
             </div>
 
             @if($recipient_id)

--- a/resources/views/livewire/chat-popup.blade.php
+++ b/resources/views/livewire/chat-popup.blade.php
@@ -18,12 +18,26 @@
                 <div class="flex {{ $msg->user_id === auth()->id() ? 'justify-end' : 'justify-start' }}">
                     <div class="px-3 py-2 rounded-lg max-w-[70%] text-sm {{ $msg->user_id === auth()->id() ? 'bg-indigo-600 text-white' : 'bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-100' }}">
                         <div>{{ $msg->message }}</div>
-                        <div class="text-[10px] text-right mt-1 opacity-70">{{ $msg->created_at->format('H:i') }}</div>
+                        <div class="text-[10px] text-right mt-1 opacity-70">
+                            {{ $msg->created_at->format('H:i') }}
+                            @if($msg->user_id === auth()->id())
+                                @if($msg->seen_at)
+                                    <span>- Read</span>
+                                @elseif($msg->delivered_at)
+                                    <span>- Delivered</span>
+                                @else
+                                    <span>- Sent</span>
+                                @endif
+                            @endif
+                        </div>
                     </div>
                 </div>
             @empty
                 <div class="text-sm text-gray-500">No messages</div>
             @endforelse
+            @if($this->isTyping)
+                <div class="text-sm text-gray-500">Typing...</div>
+            @endif
         </div>
         <form wire:submit.prevent="send" class="flex border-t border-gray-200 dark:border-gray-700">
             <input type="text" wire:model="message" class="flex-1 p-2 rounded-bl-lg focus:outline-none dark:bg-gray-800" placeholder="Type a message...">

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -6,3 +6,7 @@ Broadcast::channel('chat-assigned.{userId}', function ($user, $userId) {
     return (int) $user->id === (int) $userId;
 });
 
+Broadcast::channel('chat.{userId}', function ($user, $userId) {
+    return (int) $user->id === (int) $userId;
+});
+

--- a/tests/Feature/ChatTest.php
+++ b/tests/Feature/ChatTest.php
@@ -66,7 +66,7 @@ class ChatTest extends TestCase
                 return ($counts[$sender->id] ?? 0) === 0;
             });
 
-        $this->assertNotNull(ChatMessage::first()->fresh()->read_at);
+        $this->assertNotNull(ChatMessage::first()->fresh()->seen_at);
     }
 
     public function test_message_respects_max_length_setting(): void


### PR DESCRIPTION
## Summary
- add delivered_at and seen_at fields for chat messages
- broadcast chat messages and typing indicators in private channels
- display message statuses and typing hints in chat UIs

## Testing
- `composer test` *(fails: require(/workspace/laravel-livewire-question-bank-project/vendor/autoload.php): Failed to open stream)*
- `composer install` *(fails: Failed to download graham-campbell/result-type from dist: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ac757dbb6c832692a1297e9740b81a