### PR TITLE
Queue chat messages asynchronously

### DIFF
--- a/app/Events/ChatMessageSent.php
+++ b/app/Events/ChatMessageSent.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\ChatMessage;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ChatMessageSent implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public ChatMessage $message;
+
+    public function __construct(ChatMessage $message)
+    {
+        $this->message = $message;
+    }
+
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('chat.' . $this->message->recipient_id),
+            new PrivateChannel('chat.' . $this->message->user_id),
+        ];
+    }
+
+    public function broadcastWith(): array
+    {
+        return ['message' => $this->message->load('user')->toArray()];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'ChatMessageSent';
+    }
+}

--- a/app/Jobs/SendChatMessage.php
+++ b/app/Jobs/SendChatMessage.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Events\ChatMessageSent;
+use App\Models\ChatMessage;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class SendChatMessage implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /** @var array */
+    public array $payload;
+
+    public function __construct(array $payload)
+    {
+        $this->payload = $payload;
+    }
+
+    public function handle(): void
+    {
+        $message = ChatMessage::create($this->payload);
+        broadcast(new ChatMessageSent($message));
+    }
+}

--- a/tests/Feature/ChatPopupTest.php
+++ b/tests/Feature/ChatPopupTest.php
@@ -8,7 +8,6 @@ use App\Models\Chat;
 use App\Models\ChatMessage;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Artisan;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -21,14 +20,14 @@ class ChatPopupTest extends TestCase
         $admin = User::factory()->create(['role' => Role::ADMIN]);
         $teacher = User::factory()->create(['role' => Role::TEACHER]);
 
+        Chat::create(['user_id' => $teacher->id, 'assigned_admin_id' => $admin->id]);
+
         $this->actingAs($teacher);
 
         Livewire::test(ChatPopup::class)
             ->set('message', 'Hello Admin')
             ->call('send')
             ->assertSet('message', '');
-
-        Artisan::call('chat:flush');
 
         $this->assertDatabaseHas('chat_messages', [
             'user_id' => $teacher->id,
@@ -46,8 +45,6 @@ class ChatPopupTest extends TestCase
 
         $component = Livewire::test(ChatPopup::class);
         $component->set('message', 'Hi')->call('send');
-
-        Artisan::call('chat:flush');
 
         Chat::where('user_id', $student->id)->update(['assigned_admin_id' => $admin->id]);
         ChatMessage::where('user_id', $student->id)->update(['recipient_id' => $admin->id]);

--- a/tests/Feature/ChatTest.php
+++ b/tests/Feature/ChatTest.php
@@ -8,7 +8,6 @@ use App\Models\User;
 use App\Models\ChatMessage;
 use App\Models\Setting;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Artisan;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -28,14 +27,6 @@ class ChatTest extends TestCase
             ->set('message', 'Hello there')
             ->call('send')
             ->assertSet('message', '');
-
-        $this->assertDatabaseMissing('chat_messages', [
-            'user_id' => $sender->id,
-            'recipient_id' => $recipient->id,
-            'message' => 'Hello there',
-        ]);
-
-        Artisan::call('chat:flush');
 
         $this->assertDatabaseHas('chat_messages', [
             'user_id' => $sender->id,
@@ -94,8 +85,6 @@ class ChatTest extends TestCase
         Livewire::test(ChatPopup::class)
             ->set('message', 'Help me')
             ->call('send');
-
-        Artisan::call('chat:flush');
 
         $this->actingAs($admin);
 


### PR DESCRIPTION
## Summary
- Dispatch `SendChatMessage` job from chat components instead of caching
- Persist messages in `SendChatMessage` job and broadcast `ChatMessageSent`
- Update tests for immediate database writes

## Testing
- `composer test` *(fails: require GitHub token to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8233d0dc83268ebd97af9b5bdb42