### PR TITLE
Ensure chat messages persist immediately and prune old records

### DIFF
--- a/app/Console/Commands/CleanOldChatMessages.php
+++ b/app/Console/Commands/CleanOldChatMessages.php
@@ -3,7 +3,6 @@
 namespace App\Console\Commands;
 
 use App\Models\ChatMessage;
-use App\Models\Setting;
 use Illuminate\Console\Command;
 
 class CleanOldChatMessages extends Command
@@ -14,8 +13,7 @@ class CleanOldChatMessages extends Command
 
     public function handle(): int
     {
-        $days = Setting::get('chat_retention_days', config('chat.retention_days'));
-        $deleted = ChatMessage::where('created_at', '<', now()->subDays($days))->delete();
+        $deleted = ChatMessage::pruneAll();
         $this->info("Deleted {$deleted} old chat messages.");
         return Command::SUCCESS;
     }

--- a/app/Livewire/Admin/Chat.php
+++ b/app/Livewire/Admin/Chat.php
@@ -67,7 +67,7 @@ class Chat extends Component
     {
         $this->validate();
 
-        SendChatMessage::dispatch([
+        SendChatMessage::dispatchSync([
             'user_id' => Auth::id(),
             'recipient_id' => $this->recipient_id,
             'message' => $this->message,

--- a/app/Livewire/ChatPopup.php
+++ b/app/Livewire/ChatPopup.php
@@ -77,7 +77,7 @@ class ChatPopup extends Component
     {
         $this->validate();
 
-        SendChatMessage::dispatch([
+        SendChatMessage::dispatchSync([
             'user_id' => Auth::id(),
             'recipient_id' => $this->getAdminId(),
             'message' => $this->message,

--- a/app/Models/ChatMessage.php
+++ b/app/Models/ChatMessage.php
@@ -4,10 +4,11 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Prunable;
 
 class ChatMessage extends Model
 {
-    use HasFactory;
+    use HasFactory, Prunable;
 
     protected $fillable = [
         'user_id',
@@ -21,6 +22,12 @@ class ChatMessage extends Model
         'delivered_at' => 'datetime',
         'seen_at' => 'datetime',
     ];
+
+    public function prunable()
+    {
+        $days = Setting::get('chat_retention_days', config('chat.retention_days'));
+        return static::where('created_at', '<', now()->subDays($days));
+    }
 
     public function user()
     {

--- a/tests/Feature/ChatTest.php
+++ b/tests/Feature/ChatTest.php
@@ -102,4 +102,22 @@ class ChatTest extends TestCase
             'recipient_id' => $admin->id,
         ]);
     }
+
+    public function test_chat_clean_command_removes_old_messages(): void
+    {
+        $sender = User::factory()->create();
+        $recipient = User::factory()->create();
+
+        $message = ChatMessage::create([
+            'user_id' => $sender->id,
+            'recipient_id' => $recipient->id,
+            'message' => 'old',
+        ]);
+        $message->created_at = now()->subDays(40);
+        $message->save();
+
+        $this->artisan('chat:clean')->assertExitCode(0);
+
+        $this->assertDatabaseMissing('chat_messages', ['id' => $message->id]);
+    }
 }


### PR DESCRIPTION
## Summary
- Save chat messages synchronously so they persist even without a queue worker
- Add pruning logic for chat messages and command to purge using it
- Test cleaning command removes messages past retention period

## Testing
- `composer install` *(fails: curl error 56 while downloading packages)*
- `php artisan test` *(fails: Class "Illuminate\Foundation\Application" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8881988483269f8f2abaa5e5a10b