### PR TITLE
feat: configurable chat retention period

### DIFF
--- a/app/Livewire/Admin/Chat.php
+++ b/app/Livewire/Admin/Chat.php
@@ -158,7 +158,7 @@ class Chat extends Component
             'users' => User::where('id', '!=', Auth::id())->get(),
             'messages' => $messages,
             'messageCounts' => $messageCounts,
-            'retentionDays' => Setting::get('chat_retention_days', config('chat.retention_days')),
+            'retention' => $this->retentionPeriod(),
         ]);
     }
 
@@ -170,5 +170,13 @@ class Chat extends Component
     public function getIsTypingProperty(): bool
     {
         return $this->typing && now()->diffInSeconds($this->typing) < 5;
+    }
+
+    protected function retentionPeriod(): string
+    {
+        $hours = Setting::get('chat_retention_hours', config('chat.retention_hours'));
+        return $hours % 24 === 0
+            ? ($hours / 24) . ' days'
+            : $hours . ' hours';
     }
 }

--- a/app/Livewire/Admin/Settings.php
+++ b/app/Livewire/Admin/Settings.php
@@ -7,24 +7,35 @@ use Livewire\Component;
 
 class Settings extends Component
 {
-    public $chat_retention_days;
+    public $chat_retention_value;
+    public $chat_retention_unit = 'days';
     public $chat_message_max_length;
 
     protected $rules = [
-        'chat_retention_days' => 'required|integer|min:1',
+        'chat_retention_value' => 'required|integer|min:1',
+        'chat_retention_unit' => 'required|in:hours,days',
         'chat_message_max_length' => 'required|integer|min:1',
     ];
 
     public function mount(): void
     {
-        $this->chat_retention_days = Setting::get('chat_retention_days', config('chat.retention_days'));
+        $hours = Setting::get('chat_retention_hours', config('chat.retention_hours'));
+        if ($hours % 24 === 0) {
+            $this->chat_retention_unit = 'days';
+            $this->chat_retention_value = $hours / 24;
+        } else {
+            $this->chat_retention_unit = 'hours';
+            $this->chat_retention_value = $hours;
+        }
+
         $this->chat_message_max_length = Setting::get('chat_message_max_length', config('chat.message_max_length'));
     }
 
     public function save(): void
     {
         $this->validate();
-        Setting::set('chat_retention_days', $this->chat_retention_days);
+        $hours = $this->chat_retention_value * ($this->chat_retention_unit === 'days' ? 24 : 1);
+        Setting::set('chat_retention_hours', $hours);
         Setting::set('chat_message_max_length', $this->chat_message_max_length);
         session()->flash('status', 'Settings updated');
     }

--- a/app/Models/ChatMessage.php
+++ b/app/Models/ChatMessage.php
@@ -25,8 +25,8 @@ class ChatMessage extends Model
 
     public function prunable()
     {
-        $days = Setting::get('chat_retention_days', config('chat.retention_days'));
-        return static::where('created_at', '<', now()->subDays($days));
+        $hours = Setting::get('chat_retention_hours', config('chat.retention_hours'));
+        return static::where('created_at', '<', now()->subHours($hours));
     }
 
     public function user()

--- a/config/chat.php
+++ b/config/chat.php
@@ -1,7 +1,10 @@
 <?php
 
 return [
-    'retention_days' => env('CHAT_RETENTION_DAYS', 30),
+    // Number of hours chat messages are retained before being pruned
+    'retention_hours' => env('CHAT_RETENTION_HOURS', 30 * 24),
+
+    // Maximum length of a single chat message
     'message_max_length' => env('CHAT_MESSAGE_MAX_LENGTH', 500),
 ];
 

--- a/resources/views/livewire/admin/chat.blade.php
+++ b/resources/views/livewire/admin/chat.blade.php
@@ -1,6 +1,6 @@
 <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6 mt-6">
     <h3 class="text-lg font-semibold mb-4 text-gray-800 dark:text-white">Chat</h3>
-    <p class="text-xs text-gray-500 dark:text-gray-400 mb-4">Messages are kept for {{ $retentionDays }} days and removed automatically.</p>
+    <p class="text-xs text-gray-500 dark:text-gray-400 mb-4">Messages are kept for {{ $retention }} and removed automatically.</p>
 
     <div class="flex h-72">
         <div class="w-1/3 pr-4 border-r border-gray-200 dark:border-gray-700 overflow-y-auto h-full">

--- a/resources/views/livewire/admin/settings.blade.php
+++ b/resources/views/livewire/admin/settings.blade.php
@@ -5,9 +5,18 @@
 
     <form wire:submit.prevent="save" class="space-y-4">
         <div>
-            <label class="block text-sm font-medium mb-1">Chat retention days</label>
-            <input type="number" min="1" wire:model="chat_retention_days" class="w-full border rounded p-2">
-            @error('chat_retention_days')
+            <label class="block text-sm font-medium mb-1">Chat retention period</label>
+            <div class="flex space-x-2">
+                <input type="number" min="1" wire:model="chat_retention_value" class="w-full border rounded p-2">
+                <select wire:model="chat_retention_unit" class="border rounded p-2">
+                    <option value="hours">Hours</option>
+                    <option value="days">Days</option>
+                </select>
+            </div>
+            @error('chat_retention_value')
+                <div class="text-red-600 text-sm">{{ $message }}</div>
+            @enderror
+            @error('chat_retention_unit')
                 <div class="text-red-600 text-sm">{{ $message }}</div>
             @enderror
         </div>

--- a/routes/console.php
+++ b/routes/console.php
@@ -8,5 +8,6 @@ Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
 
-Schedule::command('chat:clean')->daily();
+// Run cleanup hourly to respect retention periods configured in hours
+Schedule::command('chat:clean')->hourly();
 Schedule::command('chat:flush')->everyMinute();


### PR DESCRIPTION
## Summary
- allow configuring chat message retention in hours or days
- prune messages based on the configured hours and run cleanup hourly
- display retention period in admin interfaces

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8e32d37c8326a402f3a55f282487