### PR TITLE
Add timezone dropdown and message limit warnings

### DIFF
--- a/app/Livewire/Admin/Chat.php
+++ b/app/Livewire/Admin/Chat.php
@@ -72,7 +72,7 @@ class Chat extends Component
             ->whereBetween('created_at', [now()->startOfDay(), now()->endOfDay()])
             ->count();
         if ($count >= $limit) {
-            $this->addError('message', 'limit');
+            $this->addError('message', "You can send {$limit} messages per day. Your limit has been reached.");
             return;
         }
 

--- a/app/Livewire/Admin/Settings.php
+++ b/app/Livewire/Admin/Settings.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Admin;
 
 use App\Models\Setting;
 use Livewire\Component;
+use DateTimeZone;
 
 class Settings extends Component
 {
@@ -12,6 +13,7 @@ class Settings extends Component
     public $chat_message_max_length;
     public $chat_daily_message_limit;
     public $timezone;
+    public array $timezones = [];
 
     protected $rules = [
         'chat_retention_value' => 'required|integer|min:1',
@@ -35,6 +37,7 @@ class Settings extends Component
         $this->chat_message_max_length = Setting::get('chat_message_max_length', config('chat.message_max_length'));
         $this->chat_daily_message_limit = Setting::get('chat_daily_message_limit', config('chat.daily_message_limit'));
         $this->timezone = Setting::get('timezone', config('app.timezone'));
+        $this->timezones = DateTimeZone::listIdentifiers();
     }
 
     public function save(): void

--- a/app/Livewire/ChatPopup.php
+++ b/app/Livewire/ChatPopup.php
@@ -83,7 +83,7 @@ class ChatPopup extends Component
             ->whereBetween('created_at', [now()->startOfDay(), now()->endOfDay()])
             ->count();
         if ($count >= $limit) {
-            $this->addError('message', 'limit');
+            $this->addError('message', "You can send {$limit} messages per day. Your limit has been reached.");
             return;
         }
 

--- a/resources/views/livewire/admin/chat.blade.php
+++ b/resources/views/livewire/admin/chat.blade.php
@@ -75,6 +75,9 @@
                     <input type="text" wire:model="message" class="flex-1 rounded-l-lg border border-gray-300 dark:border-gray-600 dark:bg-gray-700 p-2" placeholder="Type a message...">
                     <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded-r-lg">Send</button>
                 </form>
+                @error('message')
+                    <div class="text-xs text-red-600 mt-2">{{ $message }}</div>
+                @enderror
             @endif
         </div>
     </div>

--- a/resources/views/livewire/admin/settings.blade.php
+++ b/resources/views/livewire/admin/settings.blade.php
@@ -36,7 +36,11 @@
         </div>
         <div>
             <label class="block text-sm font-medium mb-1">Timezone</label>
-            <input type="text" wire:model="timezone" class="w-full border rounded p-2">
+            <select wire:model="timezone" class="w-full border rounded p-2">
+                @foreach($timezones as $tz)
+                    <option value="{{ $tz }}">{{ $tz }}</option>
+                @endforeach
+            </select>
             @error('timezone')
                 <div class="text-red-600 text-sm">{{ $message }}</div>
             @enderror

--- a/resources/views/livewire/chat-popup.blade.php
+++ b/resources/views/livewire/chat-popup.blade.php
@@ -39,6 +39,9 @@
                 <div class="text-sm text-gray-500">Typing...</div>
             @endif
         </div>
+        @error('message')
+            <div class="px-2 text-xs text-red-600">{{ $message }}</div>
+        @enderror
         <form wire:submit.prevent="send" class="flex border-t border-gray-200 dark:border-gray-700">
             <input type="text" wire:model="message" class="flex-1 p-2 rounded-bl-lg focus:outline-none dark:bg-gray-800" placeholder="Type a message...">
             <button type="submit" class="px-4 bg-indigo-600 text-white rounded-br-lg">Send</button>

--- a/tests/Feature/ChatPopupTest.php
+++ b/tests/Feature/ChatPopupTest.php
@@ -79,7 +79,7 @@ class ChatPopupTest extends TestCase
         Livewire::test(ChatPopup::class)
             ->set('message', 'Second')
             ->call('send')
-            ->assertHasErrors(['message' => 'limit']);
+            ->assertHasErrors(['message']);
     }
 }
 

--- a/tests/Feature/ChatTest.php
+++ b/tests/Feature/ChatTest.php
@@ -95,7 +95,7 @@ class ChatTest extends TestCase
             ->set('recipient_id', $recipient->id)
             ->set('message', 'second')
             ->call('send')
-            ->assertHasErrors(['message' => 'limit']);
+            ->assertHasErrors(['message']);
     }
 
     public function test_unassigned_messages_show_notification_and_assign_on_reply(): void


### PR DESCRIPTION
## Summary
- Allow admins to choose application timezone from a dropdown
- Warn users when they reach the daily chat message limit
- Update tests for new message limit handling

## Testing
- `composer test` *(fails: require vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9a4fde9483268206244908069110