### PR TITLE
Allow admin to bypass chat daily message limit

### DIFF
--- a/app/Livewire/Admin/Chat.php
+++ b/app/Livewire/Admin/Chat.php
@@ -67,13 +67,15 @@ class Chat extends Component
     {
         $this->validate();
 
-        $limit = Setting::get('chat_daily_message_limit', config('chat.daily_message_limit'));
-        $count = ChatMessage::where('user_id', Auth::id())
-            ->whereBetween('created_at', [now()->startOfDay(), now()->endOfDay()])
-            ->count();
-        if ($count >= $limit) {
-            $this->addError('message', "You can send {$limit} messages per day. Your limit has been reached.");
-            return;
+        if (!Auth::user()->isAdmin()) {
+            $limit = Setting::get('chat_daily_message_limit', config('chat.daily_message_limit'));
+            $count = ChatMessage::where('user_id', Auth::id())
+                ->whereBetween('created_at', [now()->startOfDay(), now()->endOfDay()])
+                ->count();
+            if ($count >= $limit) {
+                $this->addError('message', "You can send {$limit} messages per day. Your limit has been reached.");
+                return;
+            }
         }
 
         SendChatMessage::dispatchSync([

--- a/app/Livewire/ChatPopup.php
+++ b/app/Livewire/ChatPopup.php
@@ -78,13 +78,15 @@ class ChatPopup extends Component
     {
         $this->validate();
 
-        $limit = Setting::get('chat_daily_message_limit', config('chat.daily_message_limit'));
-        $count = ChatMessage::where('user_id', Auth::id())
-            ->whereBetween('created_at', [now()->startOfDay(), now()->endOfDay()])
-            ->count();
-        if ($count >= $limit) {
-            $this->addError('message', "You can send {$limit} messages per day. Your limit has been reached.");
-            return;
+        if (!Auth::user()->isAdmin()) {
+            $limit = Setting::get('chat_daily_message_limit', config('chat.daily_message_limit'));
+            $count = ChatMessage::where('user_id', Auth::id())
+                ->whereBetween('created_at', [now()->startOfDay(), now()->endOfDay()])
+                ->count();
+            if ($count >= $limit) {
+                $this->addError('message', "You can send {$limit} messages per day. Your limit has been reached.");
+                return;
+            }
         }
 
         SendChatMessage::dispatchSync([

--- a/tests/Feature/ChatTest.php
+++ b/tests/Feature/ChatTest.php
@@ -7,6 +7,7 @@ use App\Livewire\ChatPopup;
 use App\Models\User;
 use App\Models\ChatMessage;
 use App\Models\Setting;
+use App\Enums\Role;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 use Tests\TestCase;
@@ -96,6 +97,28 @@ class ChatTest extends TestCase
             ->set('message', 'second')
             ->call('send')
             ->assertHasErrors(['message']);
+    }
+
+    public function test_admin_can_send_unlimited_messages(): void
+    {
+        $admin = User::factory()->create(['role' => Role::ADMIN]);
+        $recipient = User::factory()->create();
+
+        Setting::set('chat_daily_message_limit', 1);
+
+        $this->actingAs($admin);
+
+        Livewire::test(Chat::class)
+            ->set('recipient_id', $recipient->id)
+            ->set('message', 'first')
+            ->call('send')
+            ->assertSet('message', '');
+
+        Livewire::test(Chat::class)
+            ->set('recipient_id', $recipient->id)
+            ->set('message', 'second')
+            ->call('send')
+            ->assertSet('message', '');
     }
 
     public function test_unassigned_messages_show_notification_and_assign_on_reply(): void


### PR DESCRIPTION
## Summary
- Allow admins to send unlimited chat messages
- Enforce daily message limit only for non-admin users
- Add test covering unlimited admin messages

## Testing
- `php artisan test` *(fails: vendor autoload missing)*
- `composer install` *(fails: Proxy CONNECT aborted / requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68aca4f576c08326acec4dbefb1b1644