### PR TITLE
feat: add job categories module

### DIFF
--- a/app/Livewire/Admin/JobCategories/Create.php
+++ b/app/Livewire/Admin/JobCategories/Create.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Livewire\Admin\JobCategories;
+
+use Livewire\Component;
+use App\Models\JobCategory;
+use Illuminate\Support\Str;
+
+class Create extends Component
+{
+    public $name;
+    public $slug;
+    public $description;
+    public $image;
+
+    public function updatedName($value)
+    {
+        $this->slug = Str::slug($value);
+    }
+
+    public function save()
+    {
+        $this->validate([
+            'name' => 'required|string|max:255',
+            'slug' => 'required|string|max:255|unique:job_categories,slug',
+            'description' => 'nullable|string',
+            'image' => 'nullable|string|max:255',
+        ]);
+
+        JobCategory::create([
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'description' => $this->description,
+            'image' => $this->image,
+        ]);
+
+        return redirect()->route('admin.job-categories.index')
+            ->with('success', 'Category created.');
+    }
+
+    public function render()
+    {
+        return view('livewire.admin.job-categories.create')
+            ->layout('layouts.admin', ['title' => 'Create Job Category']);
+    }
+}

--- a/app/Livewire/Admin/JobCategories/Edit.php
+++ b/app/Livewire/Admin/JobCategories/Edit.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Livewire\Admin\JobCategories;
+
+use Livewire\Component;
+use App\Models\JobCategory;
+use Illuminate\Support\Str;
+
+class Edit extends Component
+{
+    public JobCategory $category;
+    public $name;
+    public $slug;
+    public $description;
+    public $image;
+
+    public function mount(JobCategory $category)
+    {
+        $this->category = $category;
+        $this->name = $category->name;
+        $this->slug = $category->slug;
+        $this->description = $category->description;
+        $this->image = $category->image;
+    }
+
+    public function updatedName($value)
+    {
+        $this->slug = Str::slug($value);
+    }
+
+    public function update()
+    {
+        $this->validate([
+            'name' => 'required|string|max:255',
+            'slug' => 'required|string|max:255|unique:job_categories,slug,' . $this->category->id,
+            'description' => 'nullable|string',
+            'image' => 'nullable|string|max:255',
+        ]);
+
+        $this->category->update([
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'description' => $this->description,
+            'image' => $this->image,
+        ]);
+
+        return redirect()->route('admin.job-categories.index')
+            ->with('success', 'Category updated.');
+    }
+
+    public function render()
+    {
+        return view('livewire.admin.job-categories.edit')
+            ->layout('layouts.admin', ['title' => 'Edit Job Category']);
+    }
+}

--- a/app/Livewire/Admin/JobCategories/Index.php
+++ b/app/Livewire/Admin/JobCategories/Index.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Livewire\Admin\JobCategories;
+
+use Livewire\Component;
+use Livewire\WithPagination;
+use App\Models\JobCategory;
+
+class Index extends Component
+{
+    use WithPagination;
+
+    public $search = '';
+
+    protected $listeners = [
+        'categoryDeleted' => '$refresh',
+        'deleteCategoryConfirmed' => 'delete',
+    ];
+
+    public function updatingSearch(): void
+    {
+        $this->resetPage();
+    }
+
+    public function delete($id): void
+    {
+        JobCategory::findOrFail($id)->delete();
+        $this->resetPage();
+        $this->dispatch('categoryDeleted', message: 'Category deleted successfully.');
+    }
+
+    public function render()
+    {
+        $categories = JobCategory::when($this->search, function ($query) {
+                $query->where('name', 'like', '%'.$this->search.'%');
+            })
+            ->orderBy('name')
+            ->paginate(10);
+
+        return view('livewire.admin.job-categories.index', [
+            'categories' => $categories,
+        ])->layout('layouts.admin', ['title' => 'Job Categories']);
+    }
+}

--- a/app/Livewire/Admin/Jobs/Create.php
+++ b/app/Livewire/Admin/Jobs/Create.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Admin\Jobs;
 
 use Livewire\Component;
 use App\Models\JobPost;
+use App\Models\JobCategory;
 use App\Enums\JobStatus;
 use Illuminate\Support\Str;
 
@@ -34,7 +35,7 @@ class Create extends Component
         $this->validate([
             'title' => 'required|string|max:255',
             'slug' => 'required|string|max:255|unique:job_posts,slug',
-            'category_id' => 'nullable|integer',
+            'category_id' => 'nullable|exists:job_categories,id',
             'company_name' => 'nullable|string|max:255',
             'summary' => 'nullable|string|max:255',
             'description' => 'nullable|string',
@@ -71,7 +72,8 @@ class Create extends Component
 
     public function render()
     {
-        return view('livewire.admin.jobs.create')
-            ->layout('layouts.admin', ['title' => 'Create Job']);
+        return view('livewire.admin.jobs.create', [
+            'categories' => JobCategory::orderBy('name')->get(),
+        ])->layout('layouts.admin', ['title' => 'Create Job']);
     }
 }

--- a/app/Livewire/Admin/Jobs/Edit.php
+++ b/app/Livewire/Admin/Jobs/Edit.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Admin\Jobs;
 
 use Livewire\Component;
 use App\Models\JobPost;
+use App\Models\JobCategory;
 use App\Enums\JobStatus;
 use Illuminate\Support\Str;
 
@@ -54,7 +55,7 @@ class Edit extends Component
         $this->validate([
             'title' => 'required|string|max:255',
             'slug' => 'required|string|max:255|unique:job_posts,slug,' . $this->job->id,
-            'category_id' => 'nullable|integer',
+            'category_id' => 'nullable|exists:job_categories,id',
             'company_name' => 'nullable|string|max:255',
             'summary' => 'nullable|string|max:255',
             'description' => 'nullable|string',
@@ -91,7 +92,8 @@ class Edit extends Component
 
     public function render()
     {
-        return view('livewire.admin.jobs.edit')
-            ->layout('layouts.admin', ['title' => 'Edit Job']);
+        return view('livewire.admin.jobs.edit', [
+            'categories' => JobCategory::orderBy('name')->get(),
+        ])->layout('layouts.admin', ['title' => 'Edit Job']);
     }
 }

--- a/app/Models/JobCategory.php
+++ b/app/Models/JobCategory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class JobCategory extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'slug',
+        'description',
+        'image',
+    ];
+
+    public function jobs(): HasMany
+    {
+        return $this->hasMany(JobPost::class, 'category_id');
+    }
+}

--- a/app/Models/JobPost.php
+++ b/app/Models/JobPost.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use App\Enums\JobStatus;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class JobPost extends Model
 {
@@ -33,4 +34,9 @@ class JobPost extends Model
         'featured' => 'boolean',
         'status' => JobStatus::class,
     ];
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(JobCategory::class, 'category_id');
+    }
 }

--- a/database/migrations/2025_08_25_000001_create_job_categories_table.php
+++ b/database/migrations/2025_08_25_000001_create_job_categories_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('job_categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->text('description')->nullable();
+            $table->string('image')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('job_categories');
+    }
+};

--- a/resources/views/livewire/admin/job-categories/create.blade.php
+++ b/resources/views/livewire/admin/job-categories/create.blade.php
@@ -1,0 +1,42 @@
+<div class="max-w-3xl mx-auto bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
+    <form wire:submit.prevent="save" class="space-y-4">
+        <div>
+            <label class="block mb-1 text-sm font-medium">Name</label>
+            <input type="text" wire:model="name" class="w-full px-3 py-2 border rounded" />
+        </div>
+        <div>
+            <label class="block mb-1 text-sm font-medium">Slug</label>
+            <input type="text" wire:model="slug" class="w-full px-3 py-2 border rounded" />
+        </div>
+        <div>
+            <label class="block mb-1 text-sm font-medium">Description</label>
+            <textarea wire:model="description" class="w-full px-3 py-2 border rounded"></textarea>
+        </div>
+        <div x-data="{ imageUrl: @entangle('image') }">
+            <label class="block mb-1 text-sm font-medium">Image</label>
+            <div x-show="!imageUrl" @click="window.dispatchEvent(new CustomEvent('open-media-modal'))" class="border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-10 text-center cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700">
+                <p class="text-gray-500 dark:text-gray-400">Select Image</p>
+            </div>
+            <div x-show="imageUrl" class="space-y-2">
+                <img :src="imageUrl" class="h-32 w-32 object-cover rounded" />
+                <button type="button" @click="imageUrl = null" class="px-3 py-1 bg-red-600 text-white rounded">Remove</button>
+            </div>
+        </div>
+        <div class="text-right">
+            <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded">Save</button>
+        </div>
+    </form>
+    <x-media-modal />
+</div>
+
+@push('scripts')
+<script>
+    document.addEventListener('livewire:navigated', () => {
+        const handler = e => {
+            @this.set('image', e.detail.url);
+        };
+        window.removeEventListener('image-selected', handler);
+        window.addEventListener('image-selected', handler);
+    });
+</script>
+@endpush

--- a/resources/views/livewire/admin/job-categories/edit.blade.php
+++ b/resources/views/livewire/admin/job-categories/edit.blade.php
@@ -1,0 +1,42 @@
+<div class="max-w-3xl mx-auto bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
+    <form wire:submit.prevent="update" class="space-y-4">
+        <div>
+            <label class="block mb-1 text-sm font-medium">Name</label>
+            <input type="text" wire:model="name" class="w-full px-3 py-2 border rounded" />
+        </div>
+        <div>
+            <label class="block mb-1 text-sm font-medium">Slug</label>
+            <input type="text" wire:model="slug" class="w-full px-3 py-2 border rounded" />
+        </div>
+        <div>
+            <label class="block mb-1 text-sm font-medium">Description</label>
+            <textarea wire:model="description" class="w-full px-3 py-2 border rounded"></textarea>
+        </div>
+        <div x-data="{ imageUrl: @entangle('image') }">
+            <label class="block mb-1 text-sm font-medium">Image</label>
+            <div x-show="!imageUrl" @click="window.dispatchEvent(new CustomEvent('open-media-modal'))" class="border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-10 text-center cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700">
+                <p class="text-gray-500 dark:text-gray-400">Select Image</p>
+            </div>
+            <div x-show="imageUrl" class="space-y-2">
+                <img :src="imageUrl" class="h-32 w-32 object-cover rounded" />
+                <button type="button" @click="imageUrl = null" class="px-3 py-1 bg-red-600 text-white rounded">Remove</button>
+            </div>
+        </div>
+        <div class="text-right">
+            <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded">Update</button>
+        </div>
+    </form>
+    <x-media-modal />
+</div>
+
+@push('scripts')
+<script>
+    document.addEventListener('livewire:navigated', () => {
+        const handler = e => {
+            @this.set('image', e.detail.url);
+        };
+        window.removeEventListener('image-selected', handler);
+        window.addEventListener('image-selected', handler);
+    });
+</script>
+@endpush

--- a/resources/views/livewire/admin/job-categories/index.blade.php
+++ b/resources/views/livewire/admin/job-categories/index.blade.php
@@ -1,0 +1,93 @@
+<div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+    <div class="flex flex-col sm:flex-row sm:justify-between gap-4 mb-4">
+        <input type="text" wire:model.live.debounce.300ms="search" placeholder="Search categories..."
+               class="flex-1 px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
+        <a wire:navigate href="{{ route('admin.job-categories.create') }}"
+           class="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500">Add Category</a>
+    </div>
+
+    <div class="overflow-x-auto">
+        <table class="min-w-full text-sm divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-700">
+            <tr>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">#</th>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Image</th>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Name</th>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Slug</th>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Actions</th>
+            </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+            @forelse($categories as $category)
+                <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+                    <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $category->id }}</td>
+                    <td class="px-4 py-2">
+                        @if($category->image)
+                            <img src="{{ $category->image }}" alt="{{ $category->name }}" class="h-10 w-10 object-cover rounded">
+                        @endif
+                    </td>
+                    <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $category->name }}</td>
+                    <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $category->slug }}</td>
+                    <td class="px-4 py-2 space-x-2">
+                        <a wire:navigate href="{{ route('admin.job-categories.edit', $category) }}" class="text-indigo-600 hover:text-indigo-800">Edit</a>
+                        <button type="button" onclick="confirmDelete({{ $category->id }})" class="text-red-600 hover:text-red-800">Delete</button>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="5" class="px-4 py-6 text-center text-gray-500 dark:text-gray-400">No categories found.</td>
+                </tr>
+            @endforelse
+            </tbody>
+        </table>
+    </div>
+    <div class="mt-4">{{ $categories->links() }}</div>
+</div>
+
+@push('scripts')
+<script>
+    function showToast(message) {
+        if (!window.Swal) return;
+        Swal.fire({
+            toast: true,
+            icon: 'success',
+            title: message,
+            position: 'top-end',
+            showConfirmButton: false,
+            timer: 1500,
+        });
+    }
+
+    function confirmDelete(id) {
+        if (!window.Swal) return;
+        Swal.fire({
+            title: 'Delete this category?',
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonColor: '#d33',
+            cancelButtonColor: '#3085d6',
+            confirmButtonText: 'Yes, delete it!'
+        }).then((result) => {
+            if (result.isConfirmed) {
+                Livewire.dispatch('deleteCategoryConfirmed', { id: id });
+            }
+        });
+    }
+
+    window.sessionSuccess = @json(session('success'));
+
+    function handleSessionToast() {
+        if (window.sessionSuccess) {
+            showToast(window.sessionSuccess);
+            window.sessionSuccess = null;
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', handleSessionToast);
+    document.addEventListener('livewire:navigated', handleSessionToast);
+
+    window.addEventListener('categoryDeleted', e => {
+        showToast(e.detail.message || 'Category deleted successfully.');
+    });
+</script>
+@endpush

--- a/resources/views/livewire/admin/jobs/create.blade.php
+++ b/resources/views/livewire/admin/jobs/create.blade.php
@@ -10,8 +10,13 @@
             <input type="text" wire:model="slug" class="w-full px-3 py-2 border rounded" />
         </div>
         <div>
-            <label class="block mb-1 text-sm font-medium">Category ID</label>
-            <input type="number" wire:model="category_id" class="w-full px-3 py-2 border rounded" />
+            <label class="block mb-1 text-sm font-medium">Category</label>
+            <select wire:model="category_id" class="w-full px-3 py-2 border rounded">
+                <option value="">Select category</option>
+                @foreach($categories as $category)
+                    <option value="{{ $category->id }}">{{ $category->name }}</option>
+                @endforeach
+            </select>
         </div>
         <div>
             <label class="block mb-1 text-sm font-medium">Company Name</label>

--- a/resources/views/livewire/admin/jobs/edit.blade.php
+++ b/resources/views/livewire/admin/jobs/edit.blade.php
@@ -9,8 +9,13 @@
             <input type="text" wire:model="slug" class="w-full px-3 py-2 border rounded" />
         </div>
         <div>
-            <label class="block mb-1 text-sm font-medium">Category ID</label>
-            <input type="number" wire:model="category_id" class="w-full px-3 py-2 border rounded" />
+            <label class="block mb-1 text-sm font-medium">Category</label>
+            <select wire:model="category_id" class="w-full px-3 py-2 border rounded">
+                <option value="">Select category</option>
+                @foreach($categories as $category)
+                    <option value="{{ $category->id }}">{{ $category->name }}</option>
+                @endforeach
+            </select>
         </div>
         <div>
             <label class="block mb-1 text-sm font-medium">Company Name</label>

--- a/resources/views/livewire/admin/partials/sidebar.blade.php
+++ b/resources/views/livewire/admin/partials/sidebar.blade.php
@@ -91,6 +91,11 @@
                 <x-heroicon-o-user-group class="w-5 h-5"/>
                 <span class="sidebar-text">Users</span>
             </a>
+            <a wire:navigate href="{{ route('admin.job-categories.index') }}"
+               class="nav-link flex items-center gap-3 px-4 py-2.5 rounded-lg {{ request()->is('admin/job-categories*') ? 'bg-indigo-50 dark:bg-gray-700 text-indigo-600 dark:text-indigo-400 font-semibold' : '' }}">
+                <x-heroicon-o-rectangle-stack class="w-5 h-5"/>
+                <span class="sidebar-text">Job Categories</span>
+            </a>
             <a wire:navigate href="{{ route('admin.jobs.index') }}"
                class="nav-link flex items-center gap-3 px-4 py-2.5 rounded-lg {{ request()->is('admin/jobs*') ? 'bg-indigo-50 dark:bg-gray-700 text-indigo-600 dark:text-indigo-400 font-semibold' : '' }}">
                 <x-heroicon-o-briefcase class="w-5 h-5"/>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,9 @@ use App\Livewire\Admin\Users\Index as UserIndex;
 use App\Livewire\Admin\Jobs\Index as JobIndex;
 use App\Livewire\Admin\Jobs\Create as JobCreate;
 use App\Livewire\Admin\Jobs\Edit as JobEdit;
+use App\Livewire\Admin\JobCategories\Index as JobCategoryIndex;
+use App\Livewire\Admin\JobCategories\Create as JobCategoryCreate;
+use App\Livewire\Admin\JobCategories\Edit as JobCategoryEdit;
 use App\Livewire\Admin\Media\Index as MediaIndex;
 use App\Livewire\Teacher\Dashboard as TeacherDashboard;
 use App\Livewire\Student\Dashboard as StudentDashboard;
@@ -55,6 +58,10 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::get('/admin/jobs', JobIndex::class)->name('admin.jobs.index');
     Route::get('/admin/jobs/create', JobCreate::class)->name('admin.jobs.create');
     Route::get('/admin/jobs/{job}/edit', JobEdit::class)->name('admin.jobs.edit');
+    // Job Categories
+    Route::get('/admin/job-categories', JobCategoryIndex::class)->name('admin.job-categories.index');
+    Route::get('/admin/job-categories/create', JobCategoryCreate::class)->name('admin.job-categories.create');
+    Route::get('/admin/job-categories/{category}/edit', JobCategoryEdit::class)->name('admin.job-categories.edit');
     // Media
     Route::get('/admin/media', MediaIndex::class)->name('admin.media.index');
     Route::post('/admin/media/upload', [MediaController::class, 'store'])->name('admin.media.upload');


### PR DESCRIPTION
## Summary
- add job categories migration, model and admin CRUD Livewire components
- link job posts to categories and expose category selection in job forms
- register job category routes and sidebar navigation

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68acb39c791083268ca735d0706241a4