### PR TITLE
Improve chat message pruning

### DIFF
--- a/app/Models/ChatMessage.php
+++ b/app/Models/ChatMessage.php
@@ -4,11 +4,11 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Prunable;
+use Illuminate\Database\Eloquent\MassPrunable;
 
 class ChatMessage extends Model
 {
-    use HasFactory, Prunable;
+    use HasFactory, MassPrunable;
 
     protected $fillable = [
         'user_id',
@@ -25,7 +25,7 @@ class ChatMessage extends Model
 
     public function prunable()
     {
-        $hours = Setting::get('chat_retention_hours', config('chat.retention_hours'));
+        $hours = (int) Setting::get('chat_retention_hours', config('chat.retention_hours'));
         return static::where('created_at', '<', now()->subHours($hours));
     }
 


### PR DESCRIPTION
## Summary
- Use MassPrunable on ChatMessage for efficient deletions
- Cast retention configuration to integer before calculating cutoff

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68adc0affc9083269493b84b6b10e719