### PR TITLE
Refine typing indicators to current chat partner

### DIFF
--- a/app/Livewire/Admin/Chat.php
+++ b/app/Livewire/Admin/Chat.php
@@ -173,9 +173,11 @@ class Chat extends Component
         ]);
     }
 
-    public function showTyping(): void
+    public function showTyping($event): void
     {
-        $this->typing = now();
+        if (($event['user_id'] ?? null) === $this->recipient_id) {
+            $this->typing = now();
+        }
     }
 
     public function getIsTypingProperty(): bool

--- a/app/Livewire/ChatPopup.php
+++ b/app/Livewire/ChatPopup.php
@@ -183,9 +183,11 @@ class ChatPopup extends Component
         ]);
     }
 
-    public function showTyping(): void
+    public function showTyping($event): void
     {
-        $this->typing = now();
+        if (($event['user_id'] ?? null) === $this->getAdminId()) {
+            $this->typing = now();
+        }
     }
 
     public function getIsTypingProperty(): bool


### PR DESCRIPTION
## Summary
- Only show typing indicator when event comes from active chat recipient
- Track admin typing per selected user

## Testing
- ⚠️ `php artisan test` *(failed: vendor autoload missing; composer install requires GitHub token)*


------
https://chatgpt.com/codex/tasks/task_e_68af38697470832688c1cb6ffb78ceff