### PR TITLE
fix: reset editor content when switching job

### DIFF
--- a/resources/views/livewire/admin/jobs/edit.blade.php
+++ b/resources/views/livewire/admin/jobs/edit.blade.php
@@ -101,41 +101,48 @@
 
         function initializeQuill() {
             const editorEl = document.getElementById('description-editor');
-            if (editorEl && !editorEl.__quill) {
-                const toolbarOptions = [
-                    ['bold', 'italic', 'underline', 'strike'],
-                    ['blockquote', 'code-block'],
-                    [{ 'header': 1 }, { 'header': 2 }],
-                    [{ 'list': 'ordered'}, { 'list': 'bullet' }],
-                    ['link', 'image', 'video'],
-                    ['clean'],
-                ];
+            if (!editorEl) return;
 
-                quillInstance = new Quill(editorEl, {
-                    theme: 'snow',
-                    modules: { toolbar: toolbarOptions }
-                });
-
+            if (editorEl.__quill) {
+                quillInstance = editorEl.__quill;
                 quillInstance.root.innerHTML = @js($description ?? '');
-
-                quillInstance.on('text-change', () => {
-                    @this.set('description', quillInstance.root.innerHTML, false);
-                });
-
-                quillInstance.getModule('toolbar').addHandler('image', () => {
-                    imageToReplace = null;
-                    window.dispatchEvent(new CustomEvent('open-media-modal'));
-                });
-
-                quillInstance.root.addEventListener('click', (e) => {
-                    if (e.target && e.target.tagName === 'IMG') {
-                        imageToReplace = e.target;
-                        window.dispatchEvent(new CustomEvent('open-media-modal'));
-                    }
-                });
-
-                editorEl.__quill = quillInstance;
+                @this.set('description', quillInstance.root.innerHTML, false);
+                return;
             }
+
+            const toolbarOptions = [
+                ['bold', 'italic', 'underline', 'strike'],
+                ['blockquote', 'code-block'],
+                [{ 'header': 1 }, { 'header': 2 }],
+                [{ 'list': 'ordered'}, { 'list': 'bullet' }],
+                ['link', 'image', 'video'],
+                ['clean'],
+            ];
+
+            quillInstance = new Quill(editorEl, {
+                theme: 'snow',
+                modules: { toolbar: toolbarOptions }
+            });
+
+            quillInstance.root.innerHTML = @js($description ?? '');
+
+            quillInstance.on('text-change', () => {
+                @this.set('description', quillInstance.root.innerHTML, false);
+            });
+
+            quillInstance.getModule('toolbar').addHandler('image', () => {
+                imageToReplace = null;
+                window.dispatchEvent(new CustomEvent('open-media-modal'));
+            });
+
+            quillInstance.root.addEventListener('click', (e) => {
+                if (e.target && e.target.tagName === 'IMG') {
+                    imageToReplace = e.target;
+                    window.dispatchEvent(new CustomEvent('open-media-modal'));
+                }
+            });
+
+            editorEl.__quill = quillInstance;
         }
 
         function insertOrReplaceImage(url) {


### PR DESCRIPTION
## Summary
- ensure Quill editor updates with the current job description when navigating between edits

## Testing
- `php artisan test` *(fails: requires vendor/autoload.php)*
- `composer install --no-progress --no-interaction` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ad270b6c8326a314441893b04a19