### PR TITLE
Format chat timestamps and group messages by day

### DIFF
--- a/resources/views/components/chat-message.blade.php
+++ b/resources/views/components/chat-message.blade.php
@@ -10,7 +10,7 @@
     <div class="{{ $maxWidth }} px-3 py-2 rounded-lg text-sm {{ $msg->user_id === auth()->id() ? 'bg-indigo-600 text-white' : 'bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-100' }}">
         <div>{{ $msg->message }}</div>
         <div class="text-[10px] text-right mt-1 opacity-70">
-            {{ $msg->created_at->format('H:i') }}
+            {{ $msg->created_at->format('g.ia') }}
             @if($msg->user_id === auth()->id())
                 @if($msg->seen_at)
                     <span>- Read</span>

--- a/resources/views/livewire/admin/chat.blade.php
+++ b/resources/views/livewire/admin/chat.blade.php
@@ -20,7 +20,7 @@
                                 <div class="flex justify-between">
                                     <span class="text-sm text-gray-800 dark:text-gray-100">{{ $user->name }}</span>
                                     @if($last)
-                                        <span class="text-xs text-gray-500">{{ $last->created_at->format('H:i') }}</span>
+                                        <span class="text-xs text-gray-500">{{ $last->created_at->format('g.ia') }}</span>
                                     @endif
                                 </div>
                                 <div class="flex justify-between items-center">
@@ -41,7 +41,14 @@
 
         <div class="flex-1 pl-4 flex flex-col h-full">
             <div id="chatMessages" class="flex-1 overflow-y-auto mb-4 space-y-2" wire:poll.5s>
+                @php $lastDate = null; @endphp
                 @forelse($messages as $msg)
+                    @if ($lastDate !== $msg->created_at->toDateString())
+                        <div class="text-center text-xs text-gray-500 my-2">
+                            {{ $msg->created_at->isToday() ? 'Today' : ($msg->created_at->isYesterday() ? 'Yesterday' : $msg->created_at->format('F j, Y')) }}
+                        </div>
+                        @php $lastDate = $msg->created_at->toDateString(); @endphp
+                    @endif
                     <x-chat-message :msg="$msg" :show-avatar="true" />
                 @empty
                     <div class="text-sm text-gray-500">No messages</div>

--- a/resources/views/livewire/chat-popup.blade.php
+++ b/resources/views/livewire/chat-popup.blade.php
@@ -14,7 +14,14 @@
             <button @click="open = false" class="text-gray-500">&times;</button>
         </div>
         <div id="chatMessages" class="p-2 overflow-y-auto space-y-2 h-64">
+            @php $lastDate = null; @endphp
             @forelse($messages as $msg)
+                @if ($lastDate !== $msg->created_at->toDateString())
+                    <div class="text-center text-xs text-gray-500 my-2">
+                        {{ $msg->created_at->isToday() ? 'Today' : ($msg->created_at->isYesterday() ? 'Yesterday' : $msg->created_at->format('F j, Y')) }}
+                    </div>
+                    @php $lastDate = $msg->created_at->toDateString(); @endphp
+                @endif
                 <x-chat-message :msg="$msg" max-width="max-w-[70%]" />
             @empty
                 <div class="text-sm text-gray-500">No messages</div>


### PR DESCRIPTION
## Summary
- Use dot-separated 12‑hour timestamps with am/pm for chat messages
- Group chat messages by day with Today/Yesterday/date headers for clearer context

## Testing
- `composer test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: CONNECT tunnel failed, response 403 while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f672e4a88326a6d9dcb41047be64