### PR TITLE
Fix dashboard charts initialization

### DIFF
--- a/resources/views/livewire/admin/dashboard.blade.php
+++ b/resources/views/livewire/admin/dashboard.blade.php
@@ -110,7 +110,9 @@
 
 @push('scripts')
     <script>
-        document.addEventListener('DOMContentLoaded', function () {
+        function renderAdminCharts() {
+            if (!document.querySelector('#usageChart')) return;
+
             const messageCounts = @json($messageCounts);
 
             const usageOptions = {
@@ -133,6 +135,14 @@
                 xaxis: { categories: @json($viewChartData->pluck('title')) }
             };
             new ApexCharts(document.querySelector('#viewChart'), viewOptions).render();
-        });
+        }
+
+        document.addEventListener('livewire:navigated', renderAdminCharts);
+
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', renderAdminCharts);
+        } else {
+            renderAdminCharts();
+        }
     </script>
 @endpush


### PR DESCRIPTION
## Summary
- ensure admin dashboard charts render immediately
- re-run chart initialization after Livewire navigation

## Testing
- `composer test` (fails: require vendor/autoload.php)
- `composer install` (fails: GitHub token required)

------
https://chatgpt.com/codex/tasks/task_e_68b30370b3108326a7d5608c5cd3c43f