### PR TITLE
fix: prevent media uploader from appearing when viewing details

### DIFF
--- a/resources/views/livewire/admin/media/index.blade.php
+++ b/resources/views/livewire/admin/media/index.blade.php
@@ -32,7 +32,7 @@
 
     <div
         x-show="isDetailsDrawerOpen"
-        @open-details-drawer.window="isDetailsDrawerOpen = true"
+        @open-details-drawer.window="isDetailsDrawerOpen = true; isUploaderOpen = false"
         x-transition:enter="transition ease-in-out duration-300"
         x-transition:enter-start="translate-x-full"
         x-transition:enter-end="translate-x-0"
@@ -199,6 +199,7 @@
                 },
                 init() {
                     Livewire.on('open-details-drawer', () => {
+                        this.isUploaderOpen = false;
                         this.isDetailsDrawerOpen = true;
                     });
 


### PR DESCRIPTION
## Summary
- ensure the media uploader closes when opening the media details drawer
- avoid uploader overlay blocking other buttons when inspecting media

## Testing
- `composer install` *(fails: requires GitHub token)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b30e50a55883269bb6bd1c113c8d75