### PR TITLE
Fix media manager page missing layout

### DIFF
--- a/app/Livewire/Admin/Media/Index.php
+++ b/app/Livewire/Admin/Media/Index.php
@@ -170,7 +170,9 @@ class Index extends Component
     public function render()
     {
         $mediaItems = Media::latest()->paginate(18);
-        return view('livewire.admin.media.index', compact('mediaItems'));
+
+        return view('livewire.admin.media.index', compact('mediaItems'))
+            ->layout('layouts.admin', ['title' => 'Media Library']);
     }
 
     #[On('deleteMediaConfirmed')]


### PR DESCRIPTION
## Summary
- Ensure media manager component uses the admin layout so Livewire and asset scripts load

## Testing
- `composer test` *(fails: artisan config:clear could not find vendor autoload)*
- `composer install` *(fails: requires GitHub token to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b32f5ede2483269793a8d7bed15dd4