### PR TITLE
fix: ensure media manager waits for Livewire

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -41,15 +41,23 @@ document.addEventListener('alpine:init', () => {
             this.isUploaderOpen = true;
         },
         init() {
-            Livewire.on('open-details-drawer', () => {
-                this.isUploaderOpen = false;
-                this.isDetailsDrawerOpen = true;
-            });
+            const registerListeners = () => {
+                Livewire.on('open-details-drawer', () => {
+                    this.isUploaderOpen = false;
+                    this.isDetailsDrawerOpen = true;
+                });
 
-            Livewire.on('mediaDeleted', (e) => {
-                showToast(e.message);
-                this.isDetailsDrawerOpen = false;
-            });
+                Livewire.on('mediaDeleted', (e) => {
+                    showToast(e.message);
+                    this.isDetailsDrawerOpen = false;
+                });
+            };
+
+            if (window.Livewire) {
+                registerListeners();
+            } else {
+                window.addEventListener('livewire:load', registerListeners);
+            }
         },
 
         // copy URL to clipboard with graceful fallback


### PR DESCRIPTION
## Summary
- prevent Alpine media manager init from failing when Livewire isn't loaded yet

## Testing
- `npm run build` *(fails: Rollup failed to resolve import "alpinejs" - missing dependency)*
- `composer test` *(fails: artisan config:clear returned error 255 - vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b3539f121c8326a0d7a23f394cef34