### PR TITLE
feat: allow using env openai key for ai replies

### DIFF
--- a/app/Jobs/SendChatMessage.php
+++ b/app/Jobs/SendChatMessage.php
@@ -38,7 +38,7 @@ class SendChatMessage implements ShouldQueue
 
             if (!$recipientOnline) {
                 $enabled = Setting::get('chat_ai_enabled', false);
-                $apiKey = Setting::get('openai_api_key');
+                $apiKey = Setting::get('openai_api_key') ?: config('services.openai.key');
 
                 if ($enabled && $apiKey) {
                     try {

--- a/app/Livewire/Admin/Settings.php
+++ b/app/Livewire/Admin/Settings.php
@@ -43,7 +43,7 @@ class Settings extends Component
         $this->timezone = Setting::get('timezone', config('app.timezone'));
         $this->timezones = DateTimeZone::listIdentifiers();
         $this->chat_ai_enabled = (bool) Setting::get('chat_ai_enabled', false);
-        $this->openai_api_key = Setting::get('openai_api_key', '');
+        $this->openai_api_key = Setting::get('openai_api_key', config('services.openai.key'));
     }
 
     public function save(): void

--- a/config/services.php
+++ b/config/services.php
@@ -35,4 +35,8 @@ return [
         ],
     ],
 
+    'openai' => [
+        'key' => env('OPENAI_API_KEY'),
+    ],
+
 ];


### PR DESCRIPTION
## Summary
- read OpenAI API key from env via config/services.php
- fall back to env key when dispatching AI responses
- use env key as default on settings page

## Testing
- `composer install` *(fails: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bc56aacdb083269755b6bbc48dc433