### PR TITLE
Add AI provider selection for admin chat settings

### DIFF
--- a/app/Jobs/SendChatMessage.php
+++ b/app/Jobs/SendChatMessage.php
@@ -41,15 +41,17 @@ class SendChatMessage implements ShouldQueue
 
             if (!$recipientOnline) {
                 $enabled = Setting::get('chat_ai_enabled', false);
+                $provider = Setting::get('chat_ai_provider', 'openai');
                 $openaiKey = Setting::get('openai_api_key') ?: config('services.openai.key');
                 $geminiKey = Setting::get('gemini_api_key') ?: config('services.gemini.key');
 
-                if ($enabled && ($openaiKey || $geminiKey)) {
+                if ($enabled) {
+                    $reply = null;
                     try {
-                        if ($openaiKey) {
+                        if ($provider === 'openai' && $openaiKey) {
                             $service = app(AIResponseService::class);
                             $reply = $service->generate($message->message, $openaiKey);
-                        } else {
+                        } elseif ($provider === 'gemini' && $geminiKey) {
                             $service = app(GeminiResponseService::class);
                             $reply = $service->generate($message->message, $geminiKey);
                         }

--- a/app/Livewire/Admin/Settings.php
+++ b/app/Livewire/Admin/Settings.php
@@ -15,6 +15,7 @@ class Settings extends Component
     public $timezone;
     public array $timezones = [];
     public $chat_ai_enabled = false;
+    public $chat_ai_provider = 'openai';
     public $openai_api_key = '';
     public $gemini_api_key = '';
 
@@ -25,6 +26,7 @@ class Settings extends Component
         'chat_daily_message_limit' => 'required|integer|min:1',
         'timezone' => 'required|timezone',
         'chat_ai_enabled' => 'boolean',
+        'chat_ai_provider' => 'required|in:openai,gemini',
         'openai_api_key' => 'nullable|string',
         'gemini_api_key' => 'nullable|string',
     ];
@@ -45,6 +47,7 @@ class Settings extends Component
         $this->timezone = Setting::get('timezone', config('app.timezone'));
         $this->timezones = DateTimeZone::listIdentifiers();
         $this->chat_ai_enabled = (bool) Setting::get('chat_ai_enabled', false);
+        $this->chat_ai_provider = Setting::get('chat_ai_provider', 'openai');
         $this->openai_api_key = Setting::get('openai_api_key', config('services.openai.key'));
         $this->gemini_api_key = Setting::get('gemini_api_key', config('services.gemini.key'));
     }
@@ -58,6 +61,7 @@ class Settings extends Component
         Setting::set('chat_daily_message_limit', $this->chat_daily_message_limit);
         Setting::set('timezone', $this->timezone);
         Setting::set('chat_ai_enabled', $this->chat_ai_enabled ? 1 : 0);
+        Setting::set('chat_ai_provider', $this->chat_ai_provider);
         Setting::set('openai_api_key', $this->openai_api_key);
         Setting::set('gemini_api_key', $this->gemini_api_key);
         config(['app.timezone' => $this->timezone]);

--- a/resources/views/livewire/admin/settings.blade.php
+++ b/resources/views/livewire/admin/settings.blade.php
@@ -39,19 +39,32 @@
             <label for="chat_ai_enabled" class="text-sm font-medium">Enable AI responses when admins are offline</label>
         </div>
         <div>
-            <label class="block text-sm font-medium mb-1">OpenAI API Key</label>
-            <input type="text" wire:model="openai_api_key" class="w-full border rounded p-2">
-            @error('openai_api_key')
+            <label class="block text-sm font-medium mb-1">AI Provider</label>
+            <select wire:model="chat_ai_provider" class="w-full border rounded p-2">
+                <option value="openai">OpenAI</option>
+                <option value="gemini">Gemini</option>
+            </select>
+            @error('chat_ai_provider')
                 <div class="text-red-600 text-sm">{{ $message }}</div>
             @enderror
         </div>
-        <div>
-            <label class="block text-sm font-medium mb-1">Gemini API Key</label>
-            <input type="text" wire:model="gemini_api_key" class="w-full border rounded p-2">
-            @error('gemini_api_key')
-                <div class="text-red-600 text-sm">{{ $message }}</div>
-            @enderror
-        </div>
+        @if ($chat_ai_provider === 'openai')
+            <div>
+                <label class="block text-sm font-medium mb-1">OpenAI API Key</label>
+                <input type="text" wire:model="openai_api_key" class="w-full border rounded p-2">
+                @error('openai_api_key')
+                    <div class="text-red-600 text-sm">{{ $message }}</div>
+                @enderror
+            </div>
+        @else
+            <div>
+                <label class="block text-sm font-medium mb-1">Gemini API Key</label>
+                <input type="text" wire:model="gemini_api_key" class="w-full border rounded p-2">
+                @error('gemini_api_key')
+                    <div class="text-red-600 text-sm">{{ $message }}</div>
+                @enderror
+            </div>
+        @endif
         <div>
             <label class="block text-sm font-medium mb-1">Timezone</label>
             <select wire:model="timezone" class="w-full border rounded p-2">


### PR DESCRIPTION
## Summary
- allow admin to choose OpenAI or Gemini for chat AI
- show provider-specific API key field
- use selected provider when generating automated responses

## Testing
- `php -l app/Livewire/Admin/Settings.php`
- `php -l app/Jobs/SendChatMessage.php`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc696b67748326ab87f6d3327ef874