### PR TITLE
Switch API key input based on AI provider

### DIFF
--- a/resources/views/livewire/admin/settings.blade.php
+++ b/resources/views/livewire/admin/settings.blade.php
@@ -48,23 +48,16 @@
                 <div class="text-red-600 text-sm">{{ $message }}</div>
             @enderror
         </div>
-        @if ($chat_ai_provider === 'openai')
-            <div>
-                <label class="block text-sm font-medium mb-1">OpenAI API Key</label>
-                <input type="text" wire:model="openai_api_key" class="w-full border rounded p-2">
-                @error('openai_api_key')
-                    <div class="text-red-600 text-sm">{{ $message }}</div>
-                @enderror
-            </div>
-        @else
-            <div>
-                <label class="block text-sm font-medium mb-1">Gemini API Key</label>
-                <input type="text" wire:model="gemini_api_key" class="w-full border rounded p-2">
-                @error('gemini_api_key')
-                    <div class="text-red-600 text-sm">{{ $message }}</div>
-                @enderror
-            </div>
-        @endif
+        @php $apiKeyField = $chat_ai_provider . '_api_key'; @endphp
+        <div>
+            <label class="block text-sm font-medium mb-1">
+                {{ $chat_ai_provider === 'openai' ? 'OpenAI' : 'Gemini' }} API Key
+            </label>
+            <input type="text" wire:model="{{ $apiKeyField }}" class="w-full border rounded p-2">
+            @error($apiKeyField)
+                <div class="text-red-600 text-sm">{{ $message }}</div>
+            @enderror
+        </div>
         <div>
             <label class="block text-sm font-medium mb-1">Timezone</label>
             <select wire:model="timezone" class="w-full border rounded p-2">


### PR DESCRIPTION
## Summary
- Dynamically bind API key field to the selected AI provider in admin settings
- Simplify conditional view logic for OpenAI and Gemini keys

## Testing
- `php artisan test` *(fails: vendor autoload missing)*
- `composer install` *(fails: GitHub authentication required)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6b8b47e48326aaadc89da513ad4c