### PR TITLE
Show API key field based on provider

### DIFF
--- a/resources/views/livewire/admin/settings.blade.php
+++ b/resources/views/livewire/admin/settings.blade.php
@@ -40,7 +40,7 @@
         </div>
         <div>
             <label class="block text-sm font-medium mb-1">AI Provider</label>
-            <select wire:model="chat_ai_provider" class="w-full border rounded p-2">
+            <select wire:model.live="chat_ai_provider" class="w-full border rounded p-2">
                 <option value="openai">OpenAI</option>
                 <option value="gemini">Gemini</option>
             </select>
@@ -48,16 +48,23 @@
                 <div class="text-red-600 text-sm">{{ $message }}</div>
             @enderror
         </div>
-        @php $apiKeyField = $chat_ai_provider . '_api_key'; @endphp
-        <div>
-            <label class="block text-sm font-medium mb-1">
-                {{ $chat_ai_provider === 'openai' ? 'OpenAI' : 'Gemini' }} API Key
-            </label>
-            <input type="text" wire:model="{{ $apiKeyField }}" class="w-full border rounded p-2">
-            @error($apiKeyField)
-                <div class="text-red-600 text-sm">{{ $message }}</div>
-            @enderror
-        </div>
+        @if ($chat_ai_provider === 'openai')
+            <div>
+                <label class="block text-sm font-medium mb-1">OpenAI API Key</label>
+                <input type="text" wire:model="openai_api_key" class="w-full border rounded p-2">
+                @error('openai_api_key')
+                    <div class="text-red-600 text-sm">{{ $message }}</div>
+                @enderror
+            </div>
+        @elseif ($chat_ai_provider === 'gemini')
+            <div>
+                <label class="block text-sm font-medium mb-1">Gemini API Key</label>
+                <input type="text" wire:model="gemini_api_key" class="w-full border rounded p-2">
+                @error('gemini_api_key')
+                    <div class="text-red-600 text-sm">{{ $message }}</div>
+                @enderror
+            </div>
+        @endif
         <div>
             <label class="block text-sm font-medium mb-1">Timezone</label>
             <select wire:model="timezone" class="w-full border rounded p-2">


### PR DESCRIPTION
## Summary
- Dynamically display API key input based on selected AI provider in settings
- Use `wire:model.live` to update provider selection without page reload

## Testing
- `php artisan test` *(fails: vendor/autoload.php not found)*
- `composer install` *(fails: requires GitHub token, 403 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6dfad39c8326b33c667868b9cb7f