### PR TITLE
fix: reset API key input when provider changes

### DIFF
--- a/resources/views/livewire/admin/settings.blade.php
+++ b/resources/views/livewire/admin/settings.blade.php
@@ -49,7 +49,7 @@
             @enderror
         </div>
         @if ($chat_ai_provider === 'openai')
-            <div>
+            <div wire:key="openai-key-input">
                 <label class="block text-sm font-medium mb-1">OpenAI API Key</label>
                 <input type="text" wire:model="openai_api_key" class="w-full border rounded p-2">
                 @error('openai_api_key')
@@ -57,7 +57,7 @@
                 @enderror
             </div>
         @elseif ($chat_ai_provider === 'gemini')
-            <div>
+            <div wire:key="gemini-key-input">
                 <label class="block text-sm font-medium mb-1">Gemini API Key</label>
                 <input type="text" wire:model="gemini_api_key" class="w-full border rounded p-2">
                 @error('gemini_api_key')


### PR DESCRIPTION
## Summary
- ensure AI provider API key input resets when switching providers

## Testing
- `composer test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: CONNECT tunnel failed 403 while downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6f90e804832696c760eccbe3780d