### PR TITLE
fix: restore dashboard scripts and init libraries

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -15,6 +15,8 @@ window.Quill = Quill;
 window.TomSelect = TomSelect;
 window.ApexCharts = ApexCharts;
 window.openMathPopup = openMathPopup;
+window.Alpine = Alpine;
+Alpine.start();
 
 // --- User Menu Dropdown ---
 const userMenuButton = document.getElementById('userMenuButton');

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import Echo from 'laravel-echo';
+import Echo from 'laravel-echo/dist/echo.esm.js';
 
 window.axios = axios;
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';

--- a/resources/views/layouts/panel.blade.php
+++ b/resources/views/layouts/panel.blade.php
@@ -198,35 +198,43 @@
     styleActiveParentMenu();
 
     // --- Example Charts ---
-    new Chart(document.getElementById('subjectChart').getContext('2d'), {
-        type: 'bar',
-        data: {
-            labels: ['Math','Physics','Chemistry','Biology'],
-            datasets: [{
-                label: 'Questions',
-                data: [1200, 800, 950, 600],
-                backgroundColor: ['#3b82f6','#10b981','#f59e0b','#ef4444'],
-                borderRadius: 8
-            }]
-        },
-        options: { responsive: true, plugins: { legend: { display: false } } }
-    });
+    if (window.Chart) {
+        const subjectEl = document.getElementById('subjectChart');
+        if (subjectEl) {
+            new Chart(subjectEl.getContext('2d'), {
+                type: 'bar',
+                data: {
+                    labels: ['Math','Physics','Chemistry','Biology'],
+                    datasets: [{
+                        label: 'Questions',
+                        data: [1200, 800, 950, 600],
+                        backgroundColor: ['#3b82f6','#10b981','#f59e0b','#ef4444'],
+                        borderRadius: 8
+                    }]
+                },
+                options: { responsive: true, plugins: { legend: { display: false } } }
+            });
+        }
 
-    new Chart(document.getElementById('usageChart').getContext('2d'), {
-        type: 'line',
-        data: {
-            labels: ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'],
-            datasets: [{
-                label: 'Daily Attempts',
-                data: [120,150,200,180,250,300,280],
-                borderColor: '#6366f1',
-                backgroundColor: 'rgba(99,102,241,0.2)',
-                tension: 0.4,
-                fill: true
-            }]
-        },
-        options: { responsive: true, plugins: { legend: { display: false } } }
-    });
+        const usageEl = document.getElementById('usageChart');
+        if (usageEl) {
+            new Chart(usageEl.getContext('2d'), {
+                type: 'line',
+                data: {
+                    labels: ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'],
+                    datasets: [{
+                        label: 'Daily Attempts',
+                        data: [120,150,200,180,250,300,280],
+                        borderColor: '#6366f1',
+                        backgroundColor: 'rgba(99,102,241,0.2)',
+                        tension: 0.4,
+                        fill: true
+                    }]
+                },
+                options: { responsive: true, plugins: { legend: { display: false } } }
+            });
+        }
+    }
 </script>
 
 {{-- ✅ Livewire Scripts --}}


### PR DESCRIPTION
## Summary
- start Alpine.js and expose it globally to restore interactive components
- guard example Chart.js usage to avoid runtime errors when chart library is missing
- use ESM build of Laravel Echo for compatibility with Vite

## Testing
- `npm run build` *(fails: Rollup failed to resolve module `laravel-echo`)*
- `composer test` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bce34d94e083268ca828a5599374a3