### PR TITLE
Guard against missing register route

### DIFF
--- a/resources/views/frontend/landing.blade.php
+++ b/resources/views/frontend/landing.blade.php
@@ -7,7 +7,9 @@
     @auth
         <a href="{{ route('dashboard') }}" class="px-6 py-3 bg-indigo-600 text-white rounded-md">Go to Dashboard</a>
     @else
-        <a href="{{ route('register') }}" class="px-6 py-3 bg-indigo-600 text-white rounded-md">Get Started</a>
+        @if (Route::has('register'))
+            <a href="{{ route('register') }}" class="px-6 py-3 bg-indigo-600 text-white rounded-md">Get Started</a>
+        @endif
     @endauth
 </section>
 
@@ -33,7 +35,9 @@
     @auth
         <a href="{{ route('dashboard') }}" class="px-6 py-3 bg-indigo-600 text-white rounded-md">Go to Dashboard</a>
     @else
-        <a href="{{ route('register') }}" class="px-6 py-3 bg-indigo-600 text-white rounded-md">Create an Account</a>
+        @if (Route::has('register'))
+            <a href="{{ route('register') }}" class="px-6 py-3 bg-indigo-600 text-white rounded-md">Create an Account</a>
+        @endif
     @endauth
 </section>
 @endsection

--- a/resources/views/layouts/frontend.blade.php
+++ b/resources/views/layouts/frontend.blade.php
@@ -15,7 +15,9 @@
                     <a href="{{ route('dashboard') }}" class="text-sm text-gray-700 hover:text-gray-900">Dashboard</a>
                 @else
                     <a href="{{ route('login') }}" class="text-sm text-gray-700 hover:text-gray-900">Login</a>
-                    <a href="{{ route('register') }}" class="text-sm text-gray-700 hover:text-gray-900">Register</a>
+                    @if (Route::has('register'))
+                        <a href="{{ route('register') }}" class="text-sm text-gray-700 hover:text-gray-900">Register</a>
+                    @endif
                 @endauth
             </nav>
         </div>

--- a/resources/views/livewire/pages/auth/login.blade.php
+++ b/resources/views/livewire/pages/auth/login.blade.php
@@ -102,7 +102,7 @@ new #[Layout('layouts.guest')] class extends Component
                 {{ __('Log in') }}
             </x-primary-button>
         </div>
-        @if ($registrationEnabled)
+        @if ($registrationEnabled && Route::has('register'))
             <div class="mt-4 text-center">
                 <a class="underline text-sm text-gray-600 hover:text-gray-900" href="{{ route('register') }}" wire:navigate>{{ __('Register') }}</a>
             </div>


### PR DESCRIPTION
## Summary
- avoid missing-route errors by checking for the `register` route before linking in frontend templates
- apply same guard in login view when registration is disabled

## Testing
- `composer test` *(fails: vendor/autoload.php missing and composer install requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68be274ba504832691d4d22b85d1d481