### PR TITLE
Optimize chat performance and scalability

### DIFF
--- a/database/migrations/2025_08_27_000000_add_indexes_to_chat_messages_table.php
+++ b/database/migrations/2025_08_27_000000_add_indexes_to_chat_messages_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('chat_messages', function (Blueprint $table) {
+            $table->index(['user_id', 'recipient_id']);
+            $table->index('seen_at');
+            $table->index('created_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('chat_messages', function (Blueprint $table) {
+            $table->dropIndex(['user_id', 'recipient_id']);
+            $table->dropIndex(['seen_at']);
+            $table->dropIndex(['created_at']);
+        });
+    }
+};
+

--- a/resources/views/livewire/chat-popup.blade.php
+++ b/resources/views/livewire/chat-popup.blade.php
@@ -34,7 +34,7 @@
             <div class="px-2 text-xs text-red-600">{{ $message }}</div>
         @enderror
         <form wire:submit.prevent="send" class="flex border-t border-gray-200 dark:border-gray-700">
-            <input type="text" wire:model="message" class="flex-1 p-2 rounded-bl-lg focus:outline-none dark:bg-gray-800" placeholder="Type a message...">
+            <input type="text" wire:model.debounce.1000ms="message" class="flex-1 p-2 rounded-bl-lg focus:outline-none dark:bg-gray-800" placeholder="Type a message...">
             <button type="submit" class="px-4 bg-indigo-600 text-white rounded-br-lg">Send</button>
         </form>
     </div>
@@ -51,6 +51,22 @@
         };
 
         scroll();
+        const userId = @json(Auth::id());
+
+        window.Echo.private(`chat.${userId}`)
+            .listen('ChatMessageSent', (e) => {
+                const el = document.getElementById('chatMessages');
+                if (el) {
+                    const align = e.message.user_id === userId ? 'justify-end' : 'justify-start';
+                    const bubble = e.message.user_id === userId ? 'bg-indigo-600 text-white' : 'bg-gray-200';
+                    const wrapper = document.createElement('div');
+                    wrapper.className = `flex ${align}`;
+                    wrapper.innerHTML = `<div class="${bubble} rounded-lg p-2 text-sm">${e.message.message}</div>`;
+                    el.appendChild(wrapper);
+                    scroll();
+                }
+            });
+
         Livewire.on('chat-message-sent', () => {
             scroll();
         });


### PR DESCRIPTION
## Summary
- Queue chat message sending and throttle typing notifications
- Avoid full component refreshes by appending messages via Echo and debounce inputs
- Cache chat metadata, paginate admin user list, and add DB indexes

## Testing
- `php -l app/Livewire/Admin/Chat.php`
- `php -l app/Livewire/ChatPopup.php`
- `php -l database/migrations/2025_08_27_000000_add_indexes_to_chat_messages_table.php`
- `composer install --no-interaction` *(failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_68be5ba915d0832eb67b95d8db0e6052