### PR TITLE
Fix chat message send blocked by debounce

### DIFF
--- a/resources/views/livewire/admin/chat.blade.php
+++ b/resources/views/livewire/admin/chat.blade.php
@@ -63,7 +63,7 @@
 
             @if($recipient_id)
                 <form wire:submit.prevent="send" class="flex flex-shrink-0">
-                    <input type="text" wire:model.debounce.1000ms="message" class="flex-1 rounded-l-lg border border-gray-300 dark:border-gray-600 dark:bg-gray-700 p-2" placeholder="Type a message...">
+                    <input type="text" wire:model.live="message" class="flex-1 rounded-l-lg border border-gray-300 dark:border-gray-600 dark:bg-gray-700 p-2" placeholder="Type a message...">
                     <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded-r-lg">Send</button>
                 </form>
                 @error('message')

--- a/resources/views/livewire/chat-popup.blade.php
+++ b/resources/views/livewire/chat-popup.blade.php
@@ -34,7 +34,7 @@
             <div class="px-2 text-xs text-red-600">{{ $message }}</div>
         @enderror
         <form wire:submit.prevent="send" class="flex border-t border-gray-200 dark:border-gray-700">
-            <input type="text" wire:model.debounce.1000ms="message" class="flex-1 p-2 rounded-bl-lg focus:outline-none dark:bg-gray-800" placeholder="Type a message...">
+            <input type="text" wire:model.live="message" class="flex-1 p-2 rounded-bl-lg focus:outline-none dark:bg-gray-800" placeholder="Type a message...">
             <button type="submit" class="px-4 bg-indigo-600 text-white rounded-br-lg">Send</button>
         </form>
     </div>


### PR DESCRIPTION
## Summary
- ensure chat forms sync message input immediately so validation doesn't fail

## Testing
- `composer test` *(fails: vendor/autoload.php missing)*
- `composer install --no-interaction --no-progress` *(fails: curl error 56, CONNECT tunnel failed: 403)*

------
https://chatgpt.com/codex/tasks/task_b_68be684517fc832e9e3196cc22f06859