### PR TITLE
Process chat messages synchronously to avoid dropped sends

### DIFF
--- a/app/Livewire/Admin/Chat.php
+++ b/app/Livewire/Admin/Chat.php
@@ -81,7 +81,7 @@ class Chat extends Component
             }
         }
 
-        SendChatMessage::dispatch([
+        SendChatMessage::dispatchSync([
             'user_id' => Auth::id(),
             'recipient_id' => $this->recipient_id,
             'message' => $this->message,

--- a/app/Livewire/ChatPopup.php
+++ b/app/Livewire/ChatPopup.php
@@ -91,7 +91,7 @@ class ChatPopup extends Component
             }
         }
 
-        SendChatMessage::dispatch([
+        SendChatMessage::dispatchSync([
             'user_id' => Auth::id(),
             'recipient_id' => $this->getAdminId(),
             'message' => $this->message,


### PR DESCRIPTION
## Summary
- Send chat messages synchronously in user chat popup
- Send chat messages synchronously in admin chat panel

## Testing
- `composer install` *(failed: CONNECT tunnel failed, response 403)*
- `php artisan test` *(failed: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_b_68be6c7ce3a0832ea56f689fdc13ba69