### PR TITLE
Fix live chat messages not updating instantly for admins

### DIFF
--- a/app/Events/ChatMessageSent.php
+++ b/app/Events/ChatMessageSent.php
@@ -5,11 +5,11 @@ namespace App\Events;
 use App\Models\ChatMessage;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class ChatMessageSent implements ShouldBroadcast
+class ChatMessageSent implements ShouldBroadcastNow
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 


### PR DESCRIPTION
## Summary
- broadcast chat messages immediately so admin panel refreshes without delay

## Testing
- `composer test` *(fails: Failed to clone https://github.com/symfony/polyfill-mbstring.git via https, ssh protocols, aborting.)*

------
https://chatgpt.com/codex/tasks/task_b_68be97ea2930832eaa5ee6237499c7d1