### PR TITLE
Fix admin chat not updating automatically

### DIFF
--- a/resources/views/livewire/admin/chat.blade.php
+++ b/resources/views/livewire/admin/chat.blade.php
@@ -1,4 +1,4 @@
-<div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6 mt-6">
+<div wire:poll.5s class="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6 mt-6">
     <h3 class="text-lg font-semibold mb-4 text-gray-800 dark:text-white">Chat</h3>
     <p class="text-xs text-gray-500 dark:text-gray-400 mb-4">Messages are kept for {{ $retention }} and removed automatically.</p>
 


### PR DESCRIPTION
## Summary
- refresh admin chat automatically by polling every 5 seconds

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_b_68bea6a2c898832ea6b2bbcf133dcf88