### PR TITLE
Fix chat popup message input sync

### DIFF
--- a/resources/views/livewire/chat-popup.blade.php
+++ b/resources/views/livewire/chat-popup.blade.php
@@ -34,7 +34,7 @@
             <div class="px-2 text-xs text-red-600">{{ $message }}</div>
         @enderror
         <form wire:submit.prevent="send" class="flex border-t border-gray-200 dark:border-gray-700">
-            <input type="text" wire:model.live.debounce.500ms="message" class="flex-1 p-2 rounded-bl-lg focus:outline-none dark:bg-gray-800" placeholder="Type a message...">
+            <input type="text" wire:model.live="message" class="flex-1 p-2 rounded-bl-lg focus:outline-none dark:bg-gray-800" placeholder="Type a message...">
             <button type="submit" class="px-4 bg-indigo-600 text-white rounded-br-lg">Send</button>
         </form>
     </div>


### PR DESCRIPTION
## Summary
- avoid debounce delay causing empty messages in chat popup by binding input directly to Livewire property

## Testing
- `composer test` *(fails: require(/workspace/laravel-livewire-question-bank-project/vendor/autoload.php) missing; composer install failed with GitHub 403 errors)*

------
https://chatgpt.com/codex/tasks/task_b_68bec85626c8832e9a7e833b5fd0c3cf