### PR TITLE
Store chat messages directly in database

### DIFF
--- a/app/Livewire/Admin/Chat.php
+++ b/app/Livewire/Admin/Chat.php
@@ -4,7 +4,7 @@ namespace App\Livewire\Admin;
 
 use App\Events\ChatAssigned;
 use App\Events\UserTyping;
-use App\Jobs\SendChatMessage;
+use App\Events\ChatMessageSent;
 use App\Models\Chat as ChatModel;
 use App\Models\ChatMessage;
 use App\Models\User;
@@ -85,12 +85,13 @@ class Chat extends Component
             }
         }
 
-        SendChatMessage::dispatch([
+        $message = ChatMessage::create([
             'user_id' => Auth::id(),
             'recipient_id' => $this->recipient_id,
             'message' => $this->message,
-            'created_at' => now(),
         ]);
+
+        broadcast(new ChatMessageSent($message));
 
         $this->message = '';
         $this->dispatch('chat-message-sent');

--- a/app/Livewire/ChatPopup.php
+++ b/app/Livewire/ChatPopup.php
@@ -3,7 +3,7 @@
 namespace App\Livewire;
 
 use App\Events\UserTyping;
-use App\Jobs\SendChatMessage;
+use App\Events\ChatMessageSent;
 use App\Models\Chat;
 use App\Models\ChatMessage;
 use App\Models\Setting;
@@ -92,12 +92,13 @@ class ChatPopup extends Component
             }
         }
 
-        SendChatMessage::dispatch([
+        $message = ChatMessage::create([
             'user_id' => Auth::id(),
             'recipient_id' => $this->getAdminId(),
             'message' => $this->message,
-            'created_at' => now(),
         ]);
+
+        broadcast(new ChatMessageSent($message));
 
         $this->message = '';
         $this->dispatch('chat-message-sent');


### PR DESCRIPTION
## Summary
- Persist chat messages immediately for admin and user chats
- Broadcast new messages right after saving so conversations update instantly

## Testing
- `composer install` *(fails: CONNECT tunnel failed / rate limit)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_b_68becc31cc34832eb66402d826469b43