### PR TITLE
Queue chat messages in cache for async persistence

### DIFF
--- a/app/Console/Commands/FlushChatCache.php
+++ b/app/Console/Commands/FlushChatCache.php
@@ -15,8 +15,8 @@ class FlushChatCache extends Command
     public function handle(): int
     {
         $messages = Cache::pull('chat.pending', []);
-        foreach ($messages as $message) {
-            ChatMessage::create($message);
+        if ($messages) {
+            ChatMessage::insert($messages);
         }
         $this->info('Stored '.count($messages).' cached chat messages.');
         return Command::SUCCESS;

--- a/app/Jobs/SendChatMessage.php
+++ b/app/Jobs/SendChatMessage.php
@@ -9,7 +9,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Redis;
+use Illuminate\Support\Facades\Cache;
 
 class SendChatMessage implements ShouldQueue
 {
@@ -24,7 +24,9 @@ class SendChatMessage implements ShouldQueue
 
     public function handle(): void
     {
-        Redis::rpush('pending_chat_messages', json_encode($this->payload));
+        $messages = Cache::get('chat.pending', []);
+        $messages[] = $this->payload;
+        Cache::put('chat.pending', $messages, 3600);
 
         $message = new ChatMessage($this->payload);
         broadcast(new ChatMessageSent($message));

--- a/app/Livewire/ChatPopup.php
+++ b/app/Livewire/ChatPopup.php
@@ -3,7 +3,7 @@
 namespace App\Livewire;
 
 use App\Events\UserTyping;
-use App\Events\ChatMessageSent;
+use App\Jobs\SendChatMessage;
 use App\Models\Chat;
 use App\Models\ChatMessage;
 use App\Models\Setting;
@@ -85,23 +85,36 @@ class ChatPopup extends Component
             $limit = Setting::get('chat_daily_message_limit', config('chat.daily_message_limit'));
             $count = ChatMessage::where('user_id', Auth::id())
                 ->whereBetween('created_at', [now()->startOfDay(), now()->endOfDay()])
-                ->count();
+                ->count() + $this->pendingCount();
             if ($count >= $limit) {
                 $this->addError('message', "You can send {$limit} messages per day. Your limit has been reached.");
                 return;
             }
         }
 
-        $message = ChatMessage::create([
+        $payload = [
             'user_id' => Auth::id(),
             'recipient_id' => $this->getAdminId(),
             'message' => $this->message,
-        ]);
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
 
-        broadcast(new ChatMessageSent($message));
+        SendChatMessage::dispatch($payload);
 
         $this->message = '';
         $this->dispatch('chat-message-sent');
+    }
+
+    protected function pendingCount(): int
+    {
+        $pending = Cache::get('chat.pending', []);
+        $start = now()->startOfDay();
+        $end = now()->endOfDay();
+        return collect($pending)
+            ->where('user_id', Auth::id())
+            ->filter(fn($m) => $m['created_at'] >= $start && $m['created_at'] <= $end)
+            ->count();
     }
     
     protected function markAsDelivered(): void

--- a/tests/Feature/ChatPopupTest.php
+++ b/tests/Feature/ChatPopupTest.php
@@ -17,6 +17,7 @@ class ChatPopupTest extends TestCase
 
     public function test_teacher_can_message_admin(): void
     {
+        \Illuminate\Support\Facades\Cache::flush();
         $admin = User::factory()->create(['role' => Role::ADMIN]);
         $teacher = User::factory()->create(['role' => Role::TEACHER]);
 
@@ -28,6 +29,7 @@ class ChatPopupTest extends TestCase
             ->set('message', 'Hello Admin')
             ->call('send')
             ->assertSet('message', '');
+        $this->artisan('chat:flush');
 
         $this->assertDatabaseHas('chat_messages', [
             'user_id' => $teacher->id,
@@ -38,6 +40,7 @@ class ChatPopupTest extends TestCase
 
     public function test_student_sees_admin_reply_without_reload(): void
     {
+        \Illuminate\Support\Facades\Cache::flush();
         $admin = User::factory()->create(['role' => Role::ADMIN]);
         $student = User::factory()->create(['role' => Role::TEACHER]);
 
@@ -45,6 +48,7 @@ class ChatPopupTest extends TestCase
 
         $component = Livewire::test(ChatPopup::class);
         $component->set('message', 'Hi')->call('send');
+        $this->artisan('chat:flush');
 
         Chat::where('user_id', $student->id)->update(['assigned_admin_id' => $admin->id]);
         ChatMessage::where('user_id', $student->id)->update(['recipient_id' => $admin->id]);
@@ -62,6 +66,7 @@ class ChatPopupTest extends TestCase
 
     public function test_daily_message_limit_in_chat_popup(): void
     {
+        \Illuminate\Support\Facades\Cache::flush();
         $admin = User::factory()->create(['role' => Role::ADMIN]);
         $student = User::factory()->create(['role' => Role::TEACHER]);
 
@@ -75,6 +80,7 @@ class ChatPopupTest extends TestCase
             ->set('message', 'First')
             ->call('send')
             ->assertSet('message', '');
+        $this->artisan('chat:flush');
 
         Livewire::test(ChatPopup::class)
             ->set('message', 'Second')

--- a/tests/Feature/ChatTest.php
+++ b/tests/Feature/ChatTest.php
@@ -18,6 +18,7 @@ class ChatTest extends TestCase
 
     public function test_users_can_send_messages(): void
     {
+        \Illuminate\Support\Facades\Cache::flush();
         $sender = User::factory()->create();
         $recipient = User::factory()->create();
 
@@ -28,6 +29,7 @@ class ChatTest extends TestCase
             ->set('message', 'Hello there')
             ->call('send')
             ->assertSet('message', '');
+        $this->artisan('chat:flush');
 
         $this->assertDatabaseHas('chat_messages', [
             'user_id' => $sender->id,
@@ -38,6 +40,7 @@ class ChatTest extends TestCase
 
     public function test_conversation_list_shows_latest_message(): void
     {
+        \Illuminate\Support\Facades\Cache::flush();
         $admin = User::factory()->create();
         $student = User::factory()->create();
 
@@ -56,6 +59,7 @@ class ChatTest extends TestCase
 
     public function test_unread_count_clears_after_viewing_messages(): void
     {
+        \Illuminate\Support\Facades\Cache::flush();
         $sender = User::factory()->create();
         $recipient = User::factory()->create();
 
@@ -81,6 +85,7 @@ class ChatTest extends TestCase
 
     public function test_message_respects_max_length_setting(): void
     {
+        \Illuminate\Support\Facades\Cache::flush();
         $sender = User::factory()->create();
         $recipient = User::factory()->create();
 
@@ -97,6 +102,7 @@ class ChatTest extends TestCase
 
     public function test_daily_message_limit_is_enforced(): void
     {
+        \Illuminate\Support\Facades\Cache::flush();
         $sender = User::factory()->create();
         $recipient = User::factory()->create();
 
@@ -119,6 +125,7 @@ class ChatTest extends TestCase
 
     public function test_admin_can_send_unlimited_messages(): void
     {
+        \Illuminate\Support\Facades\Cache::flush();
         $admin = User::factory()->create(['role' => Role::ADMIN]);
         $recipient = User::factory()->create();
 
@@ -131,16 +138,19 @@ class ChatTest extends TestCase
             ->set('message', 'first')
             ->call('send')
             ->assertSet('message', '');
+        $this->artisan('chat:flush');
 
         Livewire::test(Chat::class)
             ->set('recipient_id', $recipient->id)
             ->set('message', 'second')
             ->call('send')
             ->assertSet('message', '');
+        $this->artisan('chat:flush');
     }
 
     public function test_unassigned_messages_show_notification_and_assign_on_reply(): void
     {
+        \Illuminate\Support\Facades\Cache::flush();
         $admin = User::factory()->create();
         $student = User::factory()->create();
 
@@ -148,6 +158,7 @@ class ChatTest extends TestCase
         Livewire::test(ChatPopup::class)
             ->set('message', 'Help me')
             ->call('send');
+        $this->artisan('chat:flush');
 
         $this->actingAs($admin);
 


### PR DESCRIPTION
## Summary
- queue chat messages in cache via `SendChatMessage` job
- flush cached messages to DB in batch
- send methods enqueue messages and count pending messages for daily limit

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(failed: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_b_68bed0481318832eb686a1867aad9261