### PR TITLE
Store chat messages immediately to database

### DIFF
--- a/app/Jobs/SendChatMessage.php
+++ b/app/Jobs/SendChatMessage.php
@@ -9,7 +9,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Cache;
 
 class SendChatMessage implements ShouldQueue
 {
@@ -24,11 +23,10 @@ class SendChatMessage implements ShouldQueue
 
     public function handle(): void
     {
-        $messages = Cache::get('chat.pending', []);
-        $messages[] = $this->payload;
-        Cache::put('chat.pending', $messages, 3600);
+        // Persist the message immediately so both sender and recipient can
+        // retrieve it without waiting for the flush command to run.
+        $message = ChatMessage::create($this->payload);
 
-        $message = new ChatMessage($this->payload);
         broadcast(new ChatMessageSent($message));
     }
 }

--- a/tests/Feature/ChatPopupTest.php
+++ b/tests/Feature/ChatPopupTest.php
@@ -29,7 +29,6 @@ class ChatPopupTest extends TestCase
             ->set('message', 'Hello Admin')
             ->call('send')
             ->assertSet('message', '');
-        $this->artisan('chat:flush');
 
         $this->assertDatabaseHas('chat_messages', [
             'user_id' => $teacher->id,
@@ -48,7 +47,6 @@ class ChatPopupTest extends TestCase
 
         $component = Livewire::test(ChatPopup::class);
         $component->set('message', 'Hi')->call('send');
-        $this->artisan('chat:flush');
 
         Chat::where('user_id', $student->id)->update(['assigned_admin_id' => $admin->id]);
         ChatMessage::where('user_id', $student->id)->update(['recipient_id' => $admin->id]);
@@ -80,7 +78,6 @@ class ChatPopupTest extends TestCase
             ->set('message', 'First')
             ->call('send')
             ->assertSet('message', '');
-        $this->artisan('chat:flush');
 
         Livewire::test(ChatPopup::class)
             ->set('message', 'Second')

--- a/tests/Feature/ChatTest.php
+++ b/tests/Feature/ChatTest.php
@@ -29,7 +29,6 @@ class ChatTest extends TestCase
             ->set('message', 'Hello there')
             ->call('send')
             ->assertSet('message', '');
-        $this->artisan('chat:flush');
 
         $this->assertDatabaseHas('chat_messages', [
             'user_id' => $sender->id,
@@ -138,14 +137,12 @@ class ChatTest extends TestCase
             ->set('message', 'first')
             ->call('send')
             ->assertSet('message', '');
-        $this->artisan('chat:flush');
 
         Livewire::test(Chat::class)
             ->set('recipient_id', $recipient->id)
             ->set('message', 'second')
             ->call('send')
             ->assertSet('message', '');
-        $this->artisan('chat:flush');
     }
 
     public function test_unassigned_messages_show_notification_and_assign_on_reply(): void
@@ -158,7 +155,6 @@ class ChatTest extends TestCase
         Livewire::test(ChatPopup::class)
             ->set('message', 'Help me')
             ->call('send');
-        $this->artisan('chat:flush');
 
         $this->actingAs($admin);
 


### PR DESCRIPTION
## Summary
- Save chat messages directly to the database when sent
- Update chat feature tests to reflect immediate persistence

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_b_68bee24562ec832eafd5e426478dd920