### PR TITLE
Send chat messages synchronously

### DIFF
--- a/app/Livewire/Admin/Chat.php
+++ b/app/Livewire/Admin/Chat.php
@@ -93,7 +93,11 @@ class Chat extends Component
             'updated_at' => now(),
         ];
 
-        SendChatMessage::dispatch($payload);
+        // Run the job immediately so the message is persisted even if no
+        // queue worker is running. Previously, messages would be queued and
+        // never stored when the worker was down, causing chat messages to
+        // appear "unsent". dispatchSync ensures the job executes right away.
+        SendChatMessage::dispatchSync($payload);
 
         $this->message = '';
         $this->dispatch('chat-message-sent');

--- a/app/Livewire/ChatPopup.php
+++ b/app/Livewire/ChatPopup.php
@@ -100,7 +100,10 @@ class ChatPopup extends Component
             'updated_at' => now(),
         ];
 
-        SendChatMessage::dispatch($payload);
+        // Ensure the chat message is stored immediately so users don't lose
+        // messages when the queue worker is not running. Using dispatchSync
+        // executes the job right away instead of waiting for the queue.
+        SendChatMessage::dispatchSync($payload);
 
         $this->message = '';
         $this->dispatch('chat-message-sent');


### PR DESCRIPTION
## Summary
- ensure chat and chat popup components dispatch SendChatMessage synchronously so messages persist even without a queue worker

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing due to composer install requiring GitHub access)*

------
https://chatgpt.com/codex/tasks/task_b_68befdf7ed04832ea9072d8b08def45e