### PR TITLE
Handle Pusher broadcast failures in chat message job

### DIFF
--- a/app/Jobs/SendChatMessage.php
+++ b/app/Jobs/SendChatMessage.php
@@ -4,11 +4,13 @@ namespace App\Jobs;
 
 use App\Events\ChatMessageSent;
 use App\Models\ChatMessage;
+use Illuminate\Broadcasting\BroadcastException;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
 
 class SendChatMessage implements ShouldQueue
 {
@@ -27,6 +29,13 @@ class SendChatMessage implements ShouldQueue
         // retrieve it without waiting for the flush command to run.
         $message = ChatMessage::create($this->payload);
 
-        broadcast(new ChatMessageSent($message));
+        try {
+            broadcast(new ChatMessageSent($message));
+        } catch (BroadcastException $e) {
+            Log::warning('Failed to broadcast chat message.', [
+                'message_id' => $message->id,
+                'exception' => $e->getMessage(),
+            ]);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- catch `BroadcastException` when broadcasting chat messages
- log when a chat message fails to broadcast to prevent job failure

## Testing
- `composer install` *(fails: require GitHub credentials)*
- `composer test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_b_68c08dda87c0832e864aee6b84fe9c0c