### PR TITLE
feat: add configurable chat message tone

### DIFF
--- a/app/Livewire/Admin/Chat.php
+++ b/app/Livewire/Admin/Chat.php
@@ -12,6 +12,7 @@ use App\Models\Setting;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
 use Livewire\Component;
 use Livewire\WithPagination;
 
@@ -229,6 +230,8 @@ class Chat extends Component
             'messageCounts' => $messageCounts,
             'lastMessages' => $lastMessages,
             'retention' => $this->retentionPeriod(),
+            'toneEnabled' => (bool) Setting::get('chat_tone_enabled', config('chat.tone_enabled')),
+            'toneUrl' => ($path = Setting::get('chat_message_tone', config('chat.message_tone'))) ? Storage::url($path) : null,
         ]);
     }
 

--- a/app/Livewire/ChatPopup.php
+++ b/app/Livewire/ChatPopup.php
@@ -10,6 +10,7 @@ use App\Models\Setting;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
 use Livewire\Component;
 
 class ChatPopup extends Component
@@ -203,6 +204,8 @@ class ChatPopup extends Component
             'messages' => $messages,
             'unreadCount' => $this->unreadCount,
             'chatTitle' => $chatTitle,
+            'toneEnabled' => (bool) Setting::get('chat_tone_enabled', config('chat.tone_enabled')),
+            'toneUrl' => ($path = Setting::get('chat_message_tone', config('chat.message_tone'))) ? Storage::url($path) : null,
         ]);
     }
 

--- a/config/chat.php
+++ b/config/chat.php
@@ -9,5 +9,11 @@ return [
 
     // Maximum number of chat messages a user can send per day
     'daily_message_limit' => env('CHAT_DAILY_MESSAGE_LIMIT', 100),
+
+    // Whether chat message tones are enabled by default
+    'tone_enabled' => env('CHAT_TONE_ENABLED', true),
+
+    // Default path for the chat message tone. If null, a basic beep is used.
+    'message_tone' => env('CHAT_MESSAGE_TONE'),
 ];
 

--- a/resources/views/livewire/admin/chat.blade.php
+++ b/resources/views/livewire/admin/chat.blade.php
@@ -87,6 +87,8 @@
             scroll();
 
             const userId = @json(Auth::id());
+            const toneEnabled = @json($toneEnabled);
+            const toneUrl = @json($toneUrl);
 
             window.Echo.private(`chat.${userId}`)
                 .listen('ChatMessageSent', (e) => {
@@ -118,15 +120,21 @@
 
             Livewire.on('chat-message-received', () => {
                 scroll();
-                const ctx = new (window.AudioContext || window.webkitAudioContext)();
-                const oscillator = ctx.createOscillator();
-                const gain = ctx.createGain();
-                oscillator.type = 'sine';
-                oscillator.frequency.value = 1000;
-                oscillator.connect(gain);
-                gain.connect(ctx.destination);
-                oscillator.start();
-                oscillator.stop(ctx.currentTime + 0.2);
+                if (toneEnabled) {
+                    if (toneUrl) {
+                        new Audio(toneUrl).play();
+                    } else {
+                        const ctx = new (window.AudioContext || window.webkitAudioContext)();
+                        const oscillator = ctx.createOscillator();
+                        const gain = ctx.createGain();
+                        oscillator.type = 'sine';
+                        oscillator.frequency.value = 1000;
+                        oscillator.connect(gain);
+                        gain.connect(ctx.destination);
+                        oscillator.start();
+                        oscillator.stop(ctx.currentTime + 0.2);
+                    }
+                }
             });
         });
     </script>

--- a/resources/views/livewire/admin/settings.blade.php
+++ b/resources/views/livewire/admin/settings.blade.php
@@ -35,6 +35,20 @@
             @enderror
         </div>
         <div class="flex items-center space-x-2">
+            <input type="checkbox" wire:model="chat_tone_enabled" id="chat_tone_enabled">
+            <label for="chat_tone_enabled" class="text-sm font-medium">Enable chat message tone</label>
+        </div>
+        <div>
+            <label class="block text-sm font-medium mb-1">Upload chat message tone</label>
+            <input type="file" wire:model="chat_tone" accept="audio/*" class="w-full border rounded p-2">
+            @if ($chat_tone_url)
+                <audio controls class="mt-2" src="{{ $chat_tone_url }}"></audio>
+            @endif
+            @error('chat_tone')
+                <div class="text-red-600 text-sm">{{ $message }}</div>
+            @enderror
+        </div>
+        <div class="flex items-center space-x-2">
             <input type="checkbox" wire:model="chat_ai_enabled" id="chat_ai_enabled">
             <label for="chat_ai_enabled" class="text-sm font-medium">Enable AI responses when admins are offline</label>
         </div>

--- a/resources/views/livewire/chat-popup.blade.php
+++ b/resources/views/livewire/chat-popup.blade.php
@@ -52,6 +52,8 @@
 
         scroll();
         const userId = @json(Auth::id());
+        const toneEnabled = @json($toneEnabled);
+        const toneUrl = @json($toneUrl);
 
         window.Echo.private(`chat.${userId}`)
             .listen('ChatMessageSent', (e) => {
@@ -72,15 +74,21 @@
         });
         Livewire.on('chat-message-received', () => {
             scroll();
-            const ctx = new (window.AudioContext || window.webkitAudioContext)();
-            const oscillator = ctx.createOscillator();
-            const gain = ctx.createGain();
-            oscillator.type = 'sine';
-            oscillator.frequency.value = 1000;
-            oscillator.connect(gain);
-            gain.connect(ctx.destination);
-            oscillator.start();
-            oscillator.stop(ctx.currentTime + 0.2);
+            if (toneEnabled) {
+                if (toneUrl) {
+                    new Audio(toneUrl).play();
+                } else {
+                    const ctx = new (window.AudioContext || window.webkitAudioContext)();
+                    const oscillator = ctx.createOscillator();
+                    const gain = ctx.createGain();
+                    oscillator.type = 'sine';
+                    oscillator.frequency.value = 1000;
+                    oscillator.connect(gain);
+                    gain.connect(ctx.destination);
+                    oscillator.start();
+                    oscillator.stop(ctx.currentTime + 0.2);
+                }
+            }
         });
     });
 </script>

--- a/tests/Feature/ChatToneSettingsTest.php
+++ b/tests/Feature/ChatToneSettingsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\Role;
+use App\Livewire\Admin\Settings as SettingsComponent;
+use App\Models\Setting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ChatToneSettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_update_chat_tone_settings(): void
+    {
+        Storage::fake('public');
+        $admin = User::factory()->create(['role' => Role::ADMIN]);
+        $this->actingAs($admin);
+
+        $file = UploadedFile::fake()->create('tone.mp3', 10, 'audio/mpeg');
+
+        Livewire::test(SettingsComponent::class)
+            ->set('chat_tone_enabled', false)
+            ->set('chat_tone', $file)
+            ->call('save');
+
+        $this->assertSame('0', Setting::get('chat_tone_enabled'));
+        $path = Setting::get('chat_message_tone');
+        $this->assertNotNull($path);
+        Storage::disk('public')->assertExists($path);
+    }
+}
+


### PR DESCRIPTION
## Summary
- allow admins to upload and toggle chat message tone
- play uploaded tone for incoming messages
- cover message tone settings with tests

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: requires GitHub token to download packages)*

------
https://chatgpt.com/codex/tasks/task_b_68c094aa1cb0832ebcbd002079557607