### PR TITLE
Ensure chat tone plays for users

### DIFF
--- a/resources/views/livewire/chat-popup.blade.php
+++ b/resources/views/livewire/chat-popup.blade.php
@@ -42,7 +42,7 @@
 
 @push('scripts')
 <script>
-    document.addEventListener('livewire:load', () => {
+    document.addEventListener('DOMContentLoaded', () => {
         const scroll = () => {
             const el = document.getElementById('chatMessages');
             if (el) {


### PR DESCRIPTION
## Summary
- Fix chat popup script to initialize on DOMContentLoaded so chat tone plays for users

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed)*


------
https://chatgpt.com/codex/tasks/task_b_68c09bfdd584832e9818cb629bf77c11