### PR TITLE
Enable AI chat fallback when admins are offline

### DIFF
--- a/app/Services/AIResponseService.php
+++ b/app/Services/AIResponseService.php
@@ -6,8 +6,25 @@ use Illuminate\Support\Facades\Http;
 
 class AIResponseService
 {
-    public function generate(string $prompt, string $apiKey): ?string
+    public function generate(string $prompt, string $apiKey, string $provider = 'openai'): ?string
     {
+        if ($provider === 'gemini') {
+            $response = Http::post(
+                'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=' . $apiKey,
+                [
+                    'contents' => [
+                        ['parts' => [['text' => $prompt]]],
+                    ],
+                ]
+            );
+
+            if ($response->successful()) {
+                return $response->json('candidates.0.content.parts.0.text');
+            }
+
+            return null;
+        }
+
         $response = Http::withToken($apiKey)
             ->post('https://api.openai.com/v1/chat/completions', [
                 'model' => 'gpt-3.5-turbo',


### PR DESCRIPTION
## Summary
- trigger AI responses in chat when no admin is online
- support both OpenAI and Gemini in `AIResponseService`

## Testing
- `composer test` *(fails: require vendor/autoload.php: No such file or directory)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c3117cb9588326971b0458f285188b