### PR TITLE
Make admin offline threshold configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,3 +85,6 @@ GOOGLE_REDIRECT_URI="${APP_URL}/auth/google/callback"
 FACEBOOK_CLIENT_ID=
 FACEBOOK_CLIENT_SECRET=
 FACEBOOK_REDIRECT_URI="${APP_URL}/auth/facebook/callback"
+
+# Minutes an admin must be inactive before AI responses are triggered
+CHAT_AI_ADMIN_OFFLINE_MINUTES=5

--- a/app/Livewire/Admin/Settings.php
+++ b/app/Livewire/Admin/Settings.php
@@ -24,6 +24,7 @@ class Settings extends Component
     public $chat_ai_provider = 'openai';
     public $openai_api_key = '';
     public $gemini_api_key = '';
+    public $chat_ai_admin_offline_minutes;
     public $google_login_enabled = false;
     public $facebook_login_enabled = false;
     public $google_client_id = '';
@@ -44,6 +45,7 @@ class Settings extends Component
         'chat_ai_provider' => 'required|in:openai,gemini',
         'openai_api_key' => 'nullable|string',
         'gemini_api_key' => 'nullable|string',
+        'chat_ai_admin_offline_minutes' => 'required|integer|min:1',
         'google_login_enabled' => 'boolean',
         'facebook_login_enabled' => 'boolean',
         'google_client_id' => 'nullable|string',
@@ -75,6 +77,7 @@ class Settings extends Component
         $this->chat_ai_provider = Setting::get('chat_ai_provider', 'openai');
         $this->openai_api_key = Setting::get('openai_api_key', config('services.openai.key'));
         $this->gemini_api_key = Setting::get('gemini_api_key', config('services.gemini.key'));
+        $this->chat_ai_admin_offline_minutes = Setting::get('chat_ai_admin_offline_minutes', config('chat.ai_admin_offline_minutes'));
         $this->google_login_enabled = (bool) Setting::get('google_login_enabled', false);
         $this->facebook_login_enabled = (bool) Setting::get('facebook_login_enabled', false);
         $this->google_client_id = Setting::get('google_client_id', config('services.google.client_id'));
@@ -102,6 +105,7 @@ class Settings extends Component
         Setting::set('chat_ai_provider', $this->chat_ai_provider);
         Setting::set('openai_api_key', $this->openai_api_key);
         Setting::set('gemini_api_key', $this->gemini_api_key);
+        Setting::set('chat_ai_admin_offline_minutes', $this->chat_ai_admin_offline_minutes);
         Setting::set('google_login_enabled', $this->google_login_enabled ? 1 : 0);
         Setting::set('facebook_login_enabled', $this->facebook_login_enabled ? 1 : 0);
         Setting::set('google_client_id', $this->google_client_id);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use App\Enums\Role;
 use Illuminate\Support\Facades\DB;
+use App\Models\Setting;
 use Illuminate\Support\Str;
 
 class User extends Authenticatable
@@ -69,9 +70,10 @@ class User extends Authenticatable
 
     public function isOnline(): bool
     {
+        $minutes = (int) Setting::get('chat_ai_admin_offline_minutes', config('chat.ai_admin_offline_minutes'));
         return DB::table('sessions')
             ->where('user_id', $this->id)
-            ->where('last_activity', '>=', now()->subMinutes(5)->getTimestamp())
+            ->where('last_activity', '>=', now()->subMinutes($minutes)->getTimestamp())
             ->exists();
     }
 

--- a/config/chat.php
+++ b/config/chat.php
@@ -10,6 +10,9 @@ return [
     // Maximum number of chat messages a user can send per day
     'daily_message_limit' => env('CHAT_DAILY_MESSAGE_LIMIT', 100),
 
+    // Minutes an admin must be inactive before AI responses are triggered
+    'ai_admin_offline_minutes' => env('CHAT_AI_ADMIN_OFFLINE_MINUTES', 5),
+
     // Whether chat message tones are enabled by default
     'tone_enabled' => env('CHAT_TONE_ENABLED', true),
 

--- a/resources/views/livewire/admin/settings.blade.php
+++ b/resources/views/livewire/admin/settings.blade.php
@@ -62,6 +62,13 @@
                 <div class="text-red-600 text-sm">{{ $message }}</div>
             @enderror
         </div>
+        <div>
+            <label class="block text-sm font-medium mb-1">Admin offline minutes before AI responds</label>
+            <input type="number" min="1" wire:model="chat_ai_admin_offline_minutes" class="w-full border rounded p-2">
+            @error('chat_ai_admin_offline_minutes')
+                <div class="text-red-600 text-sm">{{ $message }}</div>
+            @enderror
+        </div>
         @if ($chat_ai_provider === 'openai')
             <div wire:key="openai-key-input">
                 <label class="block text-sm font-medium mb-1">OpenAI API Key</label>


### PR DESCRIPTION
## Summary
- allow setting admin offline minutes before AI responds
- store and expose new setting in admin settings UI
- use configured offline window when checking user online status

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: GitHub API requires authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68c31bdca5788326a3d1fc5335a01870