### PR TITLE
Make chapter optional when creating questions

### DIFF
--- a/app/Livewire/Admin/Questions/Create.php
+++ b/app/Livewire/Admin/Questions/Create.php
@@ -34,7 +34,7 @@ class Create extends Component
 
         $this->validate([
             'subject_id' => 'required|exists:subjects,id',
-            'chapter_id' => 'required|exists:chapters,id',
+            'chapter_id' => 'nullable|exists:chapters,id',
             'title' => 'required|string',
             'options.*.option_text' => 'required|string',
             'options' => 'array|min:2',
@@ -43,7 +43,7 @@ class Create extends Component
 
         $question = Question::create([
             'subject_id' => $this->subject_id,
-            'chapter_id' => $this->chapter_id,
+            'chapter_id' => $this->chapter_id ?: null,
             'title' => $this->title,
             'difficulty' => $this->difficulty,
             'user_id' => auth()->id(),

--- a/app/Livewire/Admin/Questions/Edit.php
+++ b/app/Livewire/Admin/Questions/Edit.php
@@ -32,7 +32,7 @@ class Edit extends Component
 
         $this->validate([
             'subject_id' => 'required|exists:subjects,id',
-            'chapter_id' => 'required|exists:chapters,id',
+            'chapter_id' => 'nullable|exists:chapters,id',
             'title' => 'required|string',
             'options.*.option_text' => 'required|string',
             'tagIds' => 'nullable|array',
@@ -40,7 +40,7 @@ class Edit extends Component
 
         $this->question->update([
             'subject_id' => $this->subject_id,
-            'chapter_id' => $this->chapter_id,
+            'chapter_id' => $this->chapter_id ?: null,
             'title' => $this->title,
             'difficulty' => $this->difficulty,
         ]);

--- a/app/Livewire/Admin/Questions/QuestionForm.php
+++ b/app/Livewire/Admin/Questions/QuestionForm.php
@@ -46,7 +46,7 @@ class QuestionForm extends Component
     {
         $data = $this->validate([
             'subject_id' => 'required',
-            'chapter_id' => 'required',
+            'chapter_id' => 'nullable|exists:chapters,id',
             'title' => 'required|string',
             'difficulty' => 'required',
             'tagIds' => 'nullable|array',
@@ -64,7 +64,7 @@ class QuestionForm extends Component
             $this->authorize('update', $q);
             $q->update([
                 'subject_id' => $this->subject_id,
-                'chapter_id' => $this->chapter_id,
+                'chapter_id' => $this->chapter_id ?: null,
                 'title' => $this->title,
                 'difficulty' => $this->difficulty,
             ]);
@@ -75,7 +75,7 @@ class QuestionForm extends Component
             $this->authorize('create', Question::class);
             $q = Question::create([
                 'subject_id' => $this->subject_id,
-                'chapter_id' => $this->chapter_id,
+                'chapter_id' => $this->chapter_id ?: null,
                 'title' => $this->title,
                 'difficulty' => $this->difficulty,
                 'user_id' => auth()->id(),

--- a/database/migrations/2025_08_14_231808_make_chapter_id_nullable_in_questions_table.php
+++ b/database/migrations/2025_08_14_231808_make_chapter_id_nullable_in_questions_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('questions', function (Blueprint $table) {
+            $table->dropForeign(['chapter_id']);
+        });
+
+        DB::statement('ALTER TABLE questions MODIFY chapter_id BIGINT UNSIGNED NULL');
+
+        Schema::table('questions', function (Blueprint $table) {
+            $table->foreign('chapter_id')->references('id')->on('chapters')->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('questions', function (Blueprint $table) {
+            $table->dropForeign(['chapter_id']);
+        });
+
+        DB::statement('ALTER TABLE questions MODIFY chapter_id BIGINT UNSIGNED NOT NULL');
+
+        Schema::table('questions', function (Blueprint $table) {
+            $table->foreign('chapter_id')->references('id')->on('chapters')->cascadeOnDelete();
+        });
+    }
+};

--- a/resources/views/livewire/admin/questions/create.blade.php
+++ b/resources/views/livewire/admin/questions/create.blade.php
@@ -12,9 +12,9 @@
                 </select>
             </div>
 
-            {{-- Chapter --}}
+            {{-- Chapter (Optional) --}}
             <div wire:ignore>
-                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Chapter</label>
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Chapter (Optional)</label>
                 <select id="chapter" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
                     <option value="">-- Select --</option>
                     @foreach($chapters as $c)

--- a/resources/views/livewire/admin/questions/edit.blade.php
+++ b/resources/views/livewire/admin/questions/edit.blade.php
@@ -12,9 +12,9 @@
                 </select>
             </div>
 
-            {{-- Chapter --}}
+            {{-- Chapter (Optional) --}}
             <div wire:ignore>
-                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Chapter</label>
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Chapter (Optional)</label>
                 <select id="chapter" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
                     <option value="">-- Select --</option>
                     @foreach($chapters as $c)

--- a/resources/views/livewire/admin/questions/question-form.blade.php
+++ b/resources/views/livewire/admin/questions/question-form.blade.php
@@ -11,9 +11,9 @@
             </select>
         </div>
 
-        {{-- Chapter --}}
+        {{-- Chapter (Optional) --}}
         <div>
-            <label>Chapter</label>
+            <label>Chapter (Optional)</label>
             <select wire:model="chapter_id" class="border p-2 rounded w-full">
                 <option value="">-- Select --</option>
                 @foreach($chapters as $c)

--- a/tests/Feature/QuestionChapterOptionalTest.php
+++ b/tests/Feature/QuestionChapterOptionalTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\{User, Subject, Question};
+
+class QuestionChapterOptionalTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_chapter_is_optional_when_creating_question(): void
+    {
+        $user = User::factory()->create();
+        $subject = Subject::create(['name' => 'Math']);
+
+        $question = Question::create([
+            'subject_id' => $subject->id,
+            'chapter_id' => null,
+            'title' => 'What is 2 + 2?',
+            'difficulty' => 'easy',
+            'user_id' => $user->id,
+        ]);
+
+        $this->assertDatabaseHas('questions', [
+            'id' => $question->id,
+            'chapter_id' => null,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- allow questions to be saved without selecting a chapter
- clarify chapter field is optional in the question form
- add migration and test to support nullable chapter

## Testing
- `php artisan test` *(fails: require vendor/autoload.php: No such file or directory)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c42a8de08883268efe1e8c573fad7d