### PR TITLE
Use TomSelect for dependent sub-subject selection when creating chapters

### DIFF
--- a/app/Livewire/Admin/Chapters/Create.php
+++ b/app/Livewire/Admin/Chapters/Create.php
@@ -13,9 +13,16 @@ class Create extends Component
     public $sub_subject_id;
     public $name;
 
-    public function updatedSubjectId(): void
+    public function updatedSubjectId($value): void
     {
         $this->sub_subject_id = null;
+
+        $subSubjects = SubSubject::where('subject_id', $value)
+            ->get()
+            ->map(fn($s) => ['value' => $s->id, 'text' => $s->name])
+            ->all();
+
+        $this->dispatch('subSubjectsUpdated', subSubjects: $subSubjects);
     }
 
     public function save()

--- a/app/Livewire/Admin/Chapters/Edit.php
+++ b/app/Livewire/Admin/Chapters/Edit.php
@@ -22,9 +22,16 @@ class Edit extends Component
         $this->name = $chapter->name;
     }
 
-    public function updatedSubjectId(): void
+    public function updatedSubjectId($value): void
     {
         $this->sub_subject_id = null;
+
+        $subSubjects = SubSubject::where('subject_id', $value)
+            ->get()
+            ->map(fn($s) => ['value' => $s->id, 'text' => $s->name])
+            ->all();
+
+        $this->dispatch('subSubjectsUpdated', subSubjects: $subSubjects);
     }
 
     public function update()

--- a/resources/views/livewire/admin/chapters/create.blade.php
+++ b/resources/views/livewire/admin/chapters/create.blade.php
@@ -1,21 +1,21 @@
 <div>
     <form wire:submit.prevent="save" class="space-y-4 max-w-md">
-        <div>
+        <div wire:ignore>
             <label class="block mb-1">Subject</label>
-            <select wire:model="subject_id" class="border p-2 rounded w-full">
+            <select id="subject" class="border p-2 rounded w-full">
                 <option value="">-- Select --</option>
                 @foreach($subjects as $sub)
-                    <option value="{{ $sub->id }}">{{ $sub->name }}</option>
+                    <option value="{{ $sub->id }}" @selected($sub->id == $subject_id)>{{ $sub->name }}</option>
                 @endforeach
             </select>
             @error('subject_id') <span class="text-red-500 text-sm">{{ $message }}</span> @enderror
         </div>
-        <div>
+        <div wire:ignore>
             <label class="block mb-1">Sub Subject</label>
-            <select wire:model="sub_subject_id" class="border p-2 rounded w-full">
+            <select id="sub_subject" class="border p-2 rounded w-full">
                 <option value="">-- Select --</option>
                 @foreach($subSubjects as $subSubject)
-                    <option value="{{ $subSubject->id }}">{{ $subSubject->name }}</option>
+                    <option value="{{ $subSubject->id }}" @selected($subSubject->id == $sub_subject_id)>{{ $subSubject->name }}</option>
                 @endforeach
             </select>
             @error('sub_subject_id') <span class="text-red-500 text-sm">{{ $message }}</span> @enderror
@@ -28,3 +28,34 @@
         <button type="submit" class="bg-green-500 text-white px-4 py-2 rounded">Save Chapter</button>
     </form>
 </div>
+
+@push('scripts')
+    <script>
+        let tsSubject, tsSubSubject;
+
+        function initSelects() {
+            if (tsSubject) tsSubject.destroy();
+            tsSubject = new TomSelect('#subject', {
+                onChange: value => @this.set('subject_id', value)
+            });
+            tsSubject.setValue(@json($subject_id), true);
+
+            if (tsSubSubject) tsSubSubject.destroy();
+            tsSubSubject = new TomSelect('#sub_subject', {
+                onChange: value => @this.set('sub_subject_id', value)
+            });
+            tsSubSubject.setValue(@json($sub_subject_id), true);
+        }
+
+        window.addEventListener('subSubjectsUpdated', e => {
+            if (!tsSubSubject) return;
+            tsSubSubject.clearOptions();
+            tsSubSubject.addOptions(e.detail.subSubjects);
+            tsSubSubject.refreshOptions(false);
+            tsSubSubject.setValue('');
+        });
+
+        document.addEventListener('livewire:load', initSelects);
+        document.addEventListener('livewire:navigated', initSelects);
+    </script>
+@endpush

--- a/resources/views/livewire/admin/chapters/edit.blade.php
+++ b/resources/views/livewire/admin/chapters/edit.blade.php
@@ -1,21 +1,21 @@
 <div>
     <form wire:submit.prevent="update" class="space-y-4 max-w-md">
-        <div>
+        <div wire:ignore>
             <label class="block mb-1">Subject</label>
-            <select wire:model="subject_id" class="border p-2 rounded w-full">
+            <select id="subject" class="border p-2 rounded w-full">
                 <option value="">-- Select --</option>
                 @foreach($subjects as $sub)
-                    <option value="{{ $sub->id }}">{{ $sub->name }}</option>
+                    <option value="{{ $sub->id }}" @selected($sub->id == $subject_id)>{{ $sub->name }}</option>
                 @endforeach
             </select>
             @error('subject_id') <span class="text-red-500 text-sm">{{ $message }}</span> @enderror
         </div>
-        <div>
+        <div wire:ignore>
             <label class="block mb-1">Sub Subject</label>
-            <select wire:model="sub_subject_id" class="border p-2 rounded w-full">
+            <select id="sub_subject" class="border p-2 rounded w-full">
                 <option value="">-- Select --</option>
                 @foreach($subSubjects as $subSubject)
-                    <option value="{{ $subSubject->id }}">{{ $subSubject->name }}</option>
+                    <option value="{{ $subSubject->id }}" @selected($subSubject->id == $sub_subject_id)>{{ $subSubject->name }}</option>
                 @endforeach
             </select>
             @error('sub_subject_id') <span class="text-red-500 text-sm">{{ $message }}</span> @enderror
@@ -28,3 +28,34 @@
         <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Update Chapter</button>
     </form>
 </div>
+
+@push('scripts')
+    <script>
+        let tsSubject, tsSubSubject;
+
+        function initSelects() {
+            if (tsSubject) tsSubject.destroy();
+            tsSubject = new TomSelect('#subject', {
+                onChange: value => @this.set('subject_id', value)
+            });
+            tsSubject.setValue(@json($subject_id), true);
+
+            if (tsSubSubject) tsSubSubject.destroy();
+            tsSubSubject = new TomSelect('#sub_subject', {
+                onChange: value => @this.set('sub_subject_id', value)
+            });
+            tsSubSubject.setValue(@json($sub_subject_id), true);
+        }
+
+        window.addEventListener('subSubjectsUpdated', e => {
+            if (!tsSubSubject) return;
+            tsSubSubject.clearOptions();
+            tsSubSubject.addOptions(e.detail.subSubjects);
+            tsSubSubject.refreshOptions(false);
+            tsSubSubject.setValue('');
+        });
+
+        document.addEventListener('livewire:load', initSelects);
+        document.addEventListener('livewire:navigated', initSelects);
+    </script>
+@endpush


### PR DESCRIPTION
## Summary
- enhance chapter create/edit forms with TomSelect dropdowns
- update Livewire components to dispatch sub-subject options dynamically

## Testing
- `php artisan test` *(fails: missing GitHub token during composer install)*

------
https://chatgpt.com/codex/tasks/task_e_68c43ae1f0c0832684c22e17986b47cd