### PR TITLE
Fix Tom Select state persistence after navigating

### DIFF
--- a/resources/views/livewire/admin/questions/create.blade.php
+++ b/resources/views/livewire/admin/questions/create.blade.php
@@ -92,45 +92,20 @@
 
         function initEditors() {
             const main = document.getElementById('editor');
-            if (!main || main.classList.contains('ql-container')) return;
 
-            quillEditors = {};
-            window.quillEditors = quillEditors;
+            if (main && !main.classList.contains('ql-container')) {
+                quillEditors = {};
+                window.quillEditors = quillEditors;
 
-            const toolbarOptions = [
-                ['bold', 'italic'],
-                [{ 'script': 'sub' }, { 'script': 'super' }],
-                ['customMath'],
-                ['clean']
-            ];
+                const toolbarOptions = [
+                    ['bold', 'italic'],
+                    [{ 'script': 'sub' }, { 'script': 'super' }],
+                    ['customMath'],
+                    ['clean']
+                ];
 
-            // --- Main Editor ---
-            let mainEditor = new Quill('#editor', {
-                theme: 'snow',
-                modules: {
-                    formula: true,
-                    toolbar: {
-                        container: toolbarOptions,
-                        handlers: {
-                            customMath: function () {
-                                openMathPopup('title');
-                            }
-                        }
-                    }
-                },
-                placeholder: 'Compose an epic...',
-            });
-            quillEditors['title'] = mainEditor;
-
-            mainEditor.on('text-change', function () {
-                @this.set('title', mainEditor.root.innerHTML);
-            });
-
-            // --- Options Editors ---
-            document.querySelectorAll('[id^="opt_editor_"]').forEach(el => {
-                if (el.classList.contains('ql-container')) return;
-                let index = el.id.replace('opt_editor_', '');
-                let optEditor = new Quill(`#${el.id}`, {
+                // --- Main Editor ---
+                let mainEditor = new Quill('#editor', {
                     theme: 'snow',
                     modules: {
                         formula: true,
@@ -138,24 +113,50 @@
                             container: toolbarOptions,
                             handlers: {
                                 customMath: function () {
-                                    openMathPopup(`option_${index}`);
+                                    openMathPopup('title');
                                 }
                             }
                         }
                     },
                     placeholder: 'Compose an epic...',
                 });
-                quillEditors[`option_${index}`] = optEditor;
+                quillEditors['title'] = mainEditor;
 
-                optEditor.on('text-change', function () {
-                    @this.set(`options.${index}.option_text`, optEditor.root.innerHTML);
+                mainEditor.on('text-change', function () {
+                    @this.set('title', mainEditor.root.innerHTML);
                 });
-            });
 
-            // Custom button icon
-            document.querySelectorAll('.ql-customMath').forEach(btn => {
-                btn.innerHTML = '∑';
-            });
+                // --- Options Editors ---
+                document.querySelectorAll('[id^="opt_editor_"]').forEach(el => {
+                    if (el.classList.contains('ql-container')) return;
+                    let index = el.id.replace('opt_editor_', '');
+                    let optEditor = new Quill(`#${el.id}`, {
+                        theme: 'snow',
+                        modules: {
+                            formula: true,
+                            toolbar: {
+                                container: toolbarOptions,
+                                handlers: {
+                                    customMath: function () {
+                                        openMathPopup(`option_${index}`);
+                                    }
+                                }
+                            }
+                        },
+                        placeholder: 'Compose an epic...',
+                    });
+                    quillEditors[`option_${index}`] = optEditor;
+
+                    optEditor.on('text-change', function () {
+                        @this.set(`options.${index}.option_text`, optEditor.root.innerHTML);
+                    });
+                });
+
+                // Custom button icon
+                document.querySelectorAll('.ql-customMath').forEach(btn => {
+                    btn.innerHTML = '∑';
+                });
+            }
 
             if (tsSubject) tsSubject.destroy();
             tsSubject = new TomSelect('#subject', {

--- a/resources/views/livewire/admin/questions/edit.blade.php
+++ b/resources/views/livewire/admin/questions/edit.blade.php
@@ -91,45 +91,20 @@
 
         function initEditors() {
             const main = document.getElementById('editor');
-            if (!main || main.classList.contains('ql-container')) return;
 
-            quillEditors = {};
-            window.quillEditors = quillEditors;
+            if (main && !main.classList.contains('ql-container')) {
+                quillEditors = {};
+                window.quillEditors = quillEditors;
 
-            const toolbarOptions = [
-                ['bold', 'italic'],
-                [{ 'script': 'sub' }, { 'script': 'super' }],
-                ['customMath'],
-                ['clean'],
-            ];
+                const toolbarOptions = [
+                    ['bold', 'italic'],
+                    [{ 'script': 'sub' }, { 'script': 'super' }],
+                    ['customMath'],
+                    ['clean'],
+                ];
 
-            // --- Main Editor ---
-            let mainEditor = new Quill('#editor', {
-                theme: 'snow',
-                modules: {
-                    formula: true,
-                    toolbar: {
-                        container: toolbarOptions,
-                        handlers: {
-                            customMath: function () {
-                                openMathPopup('title');
-                            }
-                        }
-                    }
-                },
-                placeholder: 'Compose an epic...',
-            });
-            quillEditors['title'] = mainEditor;
-
-            mainEditor.on('text-change', function () {
-                @this.set('title', mainEditor.root.innerHTML);
-            });
-
-            // --- Options Editors ---
-            document.querySelectorAll('[id^="opt_editor_"]').forEach(el => {
-                if (el.classList.contains('ql-container')) return;
-                let index = el.id.replace('opt_editor_', '');
-                let optEditor = new Quill(`#${el.id}`, {
+                // --- Main Editor ---
+                let mainEditor = new Quill('#editor', {
                     theme: 'snow',
                     modules: {
                         formula: true,
@@ -137,24 +112,50 @@
                             container: toolbarOptions,
                             handlers: {
                                 customMath: function () {
-                                    openMathPopup(`option_${index}`);
+                                    openMathPopup('title');
                                 }
                             }
                         }
                     },
                     placeholder: 'Compose an epic...',
                 });
-                quillEditors[`option_${index}`] = optEditor;
+                quillEditors['title'] = mainEditor;
 
-                optEditor.on('text-change', function () {
-                    @this.set(`options.${index}.option_text`, optEditor.root.innerHTML);
+                mainEditor.on('text-change', function () {
+                    @this.set('title', mainEditor.root.innerHTML);
                 });
-            });
 
-            // Custom button icon
-            document.querySelectorAll('.ql-customMath').forEach(btn => {
-                btn.innerHTML = '∑';
-            });
+                // --- Options Editors ---
+                document.querySelectorAll('[id^="opt_editor_"]').forEach(el => {
+                    if (el.classList.contains('ql-container')) return;
+                    let index = el.id.replace('opt_editor_', '');
+                    let optEditor = new Quill(`#${el.id}`, {
+                        theme: 'snow',
+                        modules: {
+                            formula: true,
+                            toolbar: {
+                                container: toolbarOptions,
+                                handlers: {
+                                    customMath: function () {
+                                        openMathPopup(`option_${index}`);
+                                    }
+                                }
+                            }
+                        },
+                        placeholder: 'Compose an epic...',
+                    });
+                    quillEditors[`option_${index}`] = optEditor;
+
+                    optEditor.on('text-change', function () {
+                        @this.set(`options.${index}.option_text`, optEditor.root.innerHTML);
+                    });
+                });
+
+                // Custom button icon
+                document.querySelectorAll('.ql-customMath').forEach(btn => {
+                    btn.innerHTML = '∑';
+                });
+            }
 
             if (tsSubject) tsSubject.destroy();
             tsSubject = new TomSelect('#subject', {


### PR DESCRIPTION
## Summary
- Prevent Tom Select selections carrying over when navigating between question edit/create pages
- Reinitialize Tom Select independently of Quill editors

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c44933c4d883269848540f2d220a76