### PR TITLE
Reset TomSelect values when navigating between question forms

### DIFF
--- a/resources/views/livewire/admin/questions/create.blade.php
+++ b/resources/views/livewire/admin/questions/create.blade.php
@@ -191,6 +191,7 @@
                     @this.set('tagIds', values);
                 }
             });
+            window.tsTags.setValue(@json($tagIds), true);
             @this.set('tagIds', window.tsTags.items);
         }
 

--- a/resources/views/livewire/admin/questions/edit.blade.php
+++ b/resources/views/livewire/admin/questions/edit.blade.php
@@ -190,6 +190,7 @@
                     @this.set('tagIds', values);
                 }
             });
+            window.tsTags.setValue(@json($tagIds), true);
             @this.set('tagIds', window.tsTags.items);
         }
 

--- a/resources/views/livewire/admin/questions/question-form.blade.php
+++ b/resources/views/livewire/admin/questions/question-form.blade.php
@@ -120,6 +120,7 @@
                     @this.set('tagIds', values);
                 }
             });
+            window.tsTags.setValue(@json($tagIds), true);
             @this.set('tagIds', window.tsTags.items);
         }
 


### PR DESCRIPTION
## Summary
- Initialize TomSelect with current tag IDs on question create/edit forms
- Prevent stale tag selections when switching between question forms

## Testing
- `composer test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: GitHub API 403 – requires token)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c44ef5d5a48326bff89f27e798d0d8