### PR TITLE
Reset question form selections between navigations

### DIFF
--- a/app/Livewire/Admin/Questions/Create.php
+++ b/app/Livewire/Admin/Questions/Create.php
@@ -18,6 +18,25 @@ class Create extends Component
         ['option_text' => '', 'is_correct' => false],
     ];
 
+    public function mount(): void
+    {
+        $this->resetFields();
+    }
+
+    public function resetFields(): void
+    {
+        $this->reset('subject_id', 'sub_subject_id', 'chapter_id', 'title', 'difficulty', 'tagIds', 'options');
+        $this->difficulty = 'easy';
+        $this->options = [
+            ['option_text' => '', 'is_correct' => false],
+            ['option_text' => '', 'is_correct' => false],
+            ['option_text' => '', 'is_correct' => false],
+            ['option_text' => '', 'is_correct' => false],
+        ];
+
+        $this->dispatch('reset-selects');
+    }
+
     public function updatedSubjectId($value)
     {
         $this->sub_subject_id = null;

--- a/app/Livewire/Admin/Questions/Edit.php
+++ b/app/Livewire/Admin/Questions/Edit.php
@@ -15,6 +15,8 @@ class Edit extends Component
 
     public function mount(Question $question)
     {
+        $this->resetFields();
+
         $this->authorize('update', $question);
 
         $this->question = $question;
@@ -25,6 +27,12 @@ class Edit extends Component
         $this->difficulty = $question->difficulty;
         $this->tagIds = $question->tags()->pluck('tags.id')->toArray();
         $this->options = $question->options->toArray();
+    }
+
+    public function resetFields(): void
+    {
+        $this->reset('subject_id', 'sub_subject_id', 'chapter_id', 'title', 'difficulty', 'tagIds', 'options');
+        $this->dispatch('reset-selects');
     }
 
     public function save()

--- a/resources/views/livewire/admin/questions/create.blade.php
+++ b/resources/views/livewire/admin/questions/create.blade.php
@@ -2,7 +2,7 @@
     <form wire:submit.prevent="save" class="space-y-6">
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
             {{-- Subject --}}
-            <div wire:ignore>
+            <div wire:ignore wire:key="create-subject-select">
                 <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Subject</label>
                 <select id="subject" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
                     <option value="">-- Select --</option>
@@ -13,7 +13,7 @@
             </div>
 
             {{-- Sub-Subject (Optional) --}}
-            <div wire:ignore>
+            <div wire:ignore wire:key="create-subsubject-select">
                 <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Sub-Subject (Optional)</label>
                 <select id="sub_subject" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
                     <option value="">-- Select --</option>
@@ -24,7 +24,7 @@
             </div>
 
             {{-- Chapter (Required if Sub-Subject) --}}
-            <div wire:ignore>
+            <div wire:ignore wire:key="create-chapter-select">
                 <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Chapter</label>
                 <select id="chapter" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
                     <option value="">-- Select --</option>
@@ -209,6 +209,12 @@
             tsChapter.addOptions(e.detail.chapters);
             tsChapter.refreshOptions(false);
             tsChapter.setValue('');
+        });
+
+        window.addEventListener('reset-selects', () => {
+            tsSubject?.clear(true);
+            tsSubSubject?.clear(true);
+            tsChapter?.clear(true);
         });
 
         document.addEventListener('livewire:load', initEditors);

--- a/resources/views/livewire/admin/questions/edit.blade.php
+++ b/resources/views/livewire/admin/questions/edit.blade.php
@@ -210,6 +210,12 @@
             tsChapter.setValue('');
         });
 
+        window.addEventListener('reset-selects', () => {
+            tsSubject?.clear(true);
+            tsSubSubject?.clear(true);
+            tsChapter?.clear(true);
+        });
+
         document.addEventListener('livewire:load', initEditors);
         document.addEventListener('livewire:navigated', initEditors);
     </script>


### PR DESCRIPTION
## Summary
- reset question create form state on mount and dispatch browser event to clear TomSelect selections
- reset question edit form fields and clear select inputs before loading new question data
- add key attributes and JS listeners to clear select pickers on navigation

## Testing
- `php artisan test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: CONNECT tunnel failed / GitHub 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c453ac88a88326bb372f1011633fc7