### PR TITLE
Reset TomSelect selections on question forms

### DIFF
--- a/resources/views/livewire/admin/questions/create.blade.php
+++ b/resources/views/livewire/admin/questions/create.blade.php
@@ -213,8 +213,13 @@
 
         window.addEventListener('reset-selects', () => {
             tsSubject?.clear(true);
+            tsSubject?.setValue('', true);
+
             tsSubSubject?.clear(true);
+            tsSubSubject?.setValue('', true);
+
             tsChapter?.clear(true);
+            tsChapter?.setValue('', true);
         });
 
         document.addEventListener('livewire:load', initEditors);

--- a/resources/views/livewire/admin/questions/edit.blade.php
+++ b/resources/views/livewire/admin/questions/edit.blade.php
@@ -212,8 +212,13 @@
 
         window.addEventListener('reset-selects', () => {
             tsSubject?.clear(true);
+            tsSubject?.setValue('', true);
+
             tsSubSubject?.clear(true);
+            tsSubSubject?.setValue('', true);
+
             tsChapter?.clear(true);
+            tsChapter?.setValue('', true);
         });
 
         document.addEventListener('livewire:load', initEditors);


### PR DESCRIPTION
## Summary
- ensure question create/edit forms properly reset subject, sub-subject, and chapter TomSelect instances

## Testing
- `composer test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: GitHub 403 while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c45910bc6c8326851183978aa01c78