### PR TITLE
Arrange question options in two-column grid

### DIFF
--- a/resources/views/livewire/admin/questions/create-tiptap.blade.php
+++ b/resources/views/livewire/admin/questions/create-tiptap.blade.php
@@ -9,18 +9,20 @@
         {{-- Options --}}
         <div class="space-y-2">
             <label>Options</label>
-            @foreach($options as $i => $opt)
-                <div wire:key="opt-{{ $i }}" class="flex items-center gap-2">
-                    <div wire:ignore class="flex-1">
-                        <div id="opt_editor_{{ $i }}" class="border rounded min-h-[100px] p-2 bg-white">
-                            {!! $opt['option_text'] ?? '' !!}
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                @foreach($options as $i => $opt)
+                    <div wire:key="opt-{{ $i }}" class="flex items-center gap-2">
+                        <div wire:ignore class="flex-1">
+                            <div id="opt_editor_{{ $i }}" class="border rounded min-h-[100px] p-2 bg-white">
+                                {!! $opt['option_text'] ?? '' !!}
+                            </div>
                         </div>
+                        <label>
+                            <input type="checkbox" wire:model="options.{{ $i }}.is_correct"> Correct
+                        </label>
                     </div>
-                    <label>
-                        <input type="checkbox" wire:model="options.{{ $i }}.is_correct"> Correct
-                    </label>
-                </div>
-            @endforeach
+                @endforeach
+            </div>
         </div>
 
         <button type="submit" class="bg-green-500 text-white px-4 py-2 rounded">

--- a/resources/views/livewire/admin/questions/create.blade.php
+++ b/resources/views/livewire/admin/questions/create.blade.php
@@ -65,17 +65,19 @@
         {{-- Options --}}
         <div class="space-y-4">
             <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Options</label>
-            @foreach($options as $i => $opt)
-                <div wire:key="opt-{{ $i }}" class="flex items-start gap-2">
-                    <div wire:ignore class="flex-1">
-                        <div id="opt_editor_{{ $i }}" class="border border-gray-300 dark:border-gray-600  min-h-24 p-2 dark:bg-gray-700 dark:text-gray-100"></div>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                @foreach($options as $i => $opt)
+                    <div wire:key="opt-{{ $i }}" class="flex items-start gap-2">
+                        <div wire:ignore class="flex-1">
+                            <div id="opt_editor_{{ $i }}" class="border border-gray-300 dark:border-gray-600  min-h-24 p-2 dark:bg-gray-700 dark:text-gray-100"></div>
+                        </div>
+                        <label class="flex items-center gap-1 text-sm text-gray-700 dark:text-gray-300">
+                            <input type="checkbox" wire:model="options.{{ $i }}.is_correct" class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600">
+                            <span>Correct</span>
+                        </label>
                     </div>
-                    <label class="flex items-center gap-1 text-sm text-gray-700 dark:text-gray-300">
-                        <input type="checkbox" wire:model="options.{{ $i }}.is_correct" class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600">
-                        <span>Correct</span>
-                    </label>
-                </div>
-            @endforeach
+                @endforeach
+            </div>
         </div>
 
         <button type="submit" class="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-md focus:outline-none focus:ring-2 focus:ring-green-500">

--- a/resources/views/livewire/admin/questions/edit.blade.php
+++ b/resources/views/livewire/admin/questions/edit.blade.php
@@ -64,17 +64,19 @@
         {{-- Options --}}
         <div class="space-y-4">
             <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Options</label>
-            @foreach($options as $i => $opt)
-                <div wire:key="opt-{{ $i }}" class="flex items-start gap-2">
-                    <div wire:ignore class="flex-1">
-                        <div id="opt_editor_{{ $i }}" class="border border-gray-300 dark:border-gray-600 min-h-24 p-2 dark:bg-gray-700 dark:text-gray-100">{!! $opt['option_text'] ?? '' !!}</div>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                @foreach($options as $i => $opt)
+                    <div wire:key="opt-{{ $i }}" class="flex items-start gap-2">
+                        <div wire:ignore class="flex-1">
+                            <div id="opt_editor_{{ $i }}" class="border border-gray-300 dark:border-gray-600 min-h-24 p-2 dark:bg-gray-700 dark:text-gray-100">{!! $opt['option_text'] ?? '' !!}</div>
+                        </div>
+                        <label class="flex items-center gap-1 text-sm text-gray-700 dark:text-gray-300">
+                            <input type="checkbox" wire:model="options.{{ $i }}.is_correct" class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600" @if(!empty($opt['is_correct']) && $opt['is_correct']) checked @endif>
+                            <span>Correct</span>
+                        </label>
                     </div>
-                    <label class="flex items-center gap-1 text-sm text-gray-700 dark:text-gray-300">
-                        <input type="checkbox" wire:model="options.{{ $i }}.is_correct" class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600" @if(!empty($opt['is_correct']) && $opt['is_correct']) checked @endif>
-                        <span>Correct</span>
-                    </label>
-                </div>
-            @endforeach
+                @endforeach
+            </div>
         </div>
 
         <button type="submit" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">

--- a/resources/views/livewire/admin/questions/question-form.blade.php
+++ b/resources/views/livewire/admin/questions/question-form.blade.php
@@ -51,16 +51,18 @@
         {{-- Options --}}
         <div class="space-y-2">
             <label>Options</label>
-            @foreach($options as $i => $opt)
-                <div wire:key="opt-{{ $i }}" class="flex items-center gap-2">
-                    <div wire:ignore class="flex-1">
-                        <div id="opt_editor_{{ $i }}" class="min-h-200"></div>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                @foreach($options as $i => $opt)
+                    <div wire:key="opt-{{ $i }}" class="flex items-center gap-2">
+                        <div wire:ignore class="flex-1">
+                            <div id="opt_editor_{{ $i }}" class="min-h-200"></div>
+                        </div>
+                        <label>
+                            <input type="checkbox" wire:model="options.{{ $i }}.is_correct"> Correct
+                        </label>
                     </div>
-                    <label>
-                        <input type="checkbox" wire:model="options.{{ $i }}.is_correct"> Correct
-                    </label>
-                </div>
-            @endforeach
+                @endforeach
+            </div>
         </div>
 
         <button type="submit" class="bg-green-500 text-white px-4 py-2 rounded">


### PR DESCRIPTION
## Summary
- Display answer options in a two-column grid on question creation and edit pages
- Apply the grid layout to question form partials and tiptap variant for consistency

## Testing
- `php artisan test` *(fails: require(): Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: Cloning failed using an ssh key for authentication, enter your GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68c47225cfbc8326accf8054707176c0