### PR TITLE
Hide chapter selection until sub-subject chosen

### DIFF
--- a/app/Livewire/Admin/Questions/Create.php
+++ b/app/Livewire/Admin/Questions/Create.php
@@ -54,10 +54,12 @@ class Create extends Component
     public function updatedSubSubjectId($value)
     {
         $this->chapter_id = null;
-        $chapters = Chapter::where('sub_subject_id', $value)
-            ->get()
-            ->map(fn($c) => ['value' => $c->id, 'text' => $c->name])
-            ->all();
+        $chapters = $value
+            ? Chapter::where('sub_subject_id', $value)
+                ->get()
+                ->map(fn($c) => ['value' => $c->id, 'text' => $c->name])
+                ->all()
+            : [];
         $this->dispatch('chaptersUpdated', chapters: $chapters);
     }
 

--- a/app/Livewire/Admin/Questions/Edit.php
+++ b/app/Livewire/Admin/Questions/Edit.php
@@ -90,10 +90,12 @@ class Edit extends Component
     public function updatedSubSubjectId($value)
     {
         $this->chapter_id = null;
-        $chapters = Chapter::where('sub_subject_id', $value)
-            ->get()
-            ->map(fn($c) => ['value' => $c->id, 'text' => $c->name])
-            ->all();
+        $chapters = $value
+            ? Chapter::where('sub_subject_id', $value)
+                ->get()
+                ->map(fn($c) => ['value' => $c->id, 'text' => $c->name])
+                ->all()
+            : [];
         $this->dispatch('chaptersUpdated', chapters: $chapters);
     }
 

--- a/resources/views/livewire/admin/questions/create.blade.php
+++ b/resources/views/livewire/admin/questions/create.blade.php
@@ -24,15 +24,17 @@
             </div>
 
             {{-- Chapter (Required if Sub-Subject) --}}
-            <div wire:ignore wire:key="create-chapter-select">
-                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Chapter</label>
-                <select id="chapter" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
-                    <option value="">-- Select --</option>
-                    @foreach($chapters as $c)
-                        <option value="{{ $c->id }}" @selected($c->id == $chapter_id)>{{ $c->name }}</option>
-                    @endforeach
-                </select>
-            </div>
+            @if($sub_subject_id)
+                <div wire:ignore wire:key="create-chapter-select">
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Chapter</label>
+                    <select id="chapter" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
+                        <option value="">-- Select --</option>
+                        @foreach($chapters as $c)
+                            <option value="{{ $c->id }}" @selected($c->id == $chapter_id)>{{ $c->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
+            @endif
         </div>
 
         {{-- Main Question --}}
@@ -176,13 +178,19 @@
             });
             tsSubSubject.setValue(@json($sub_subject_id), true);
 
-            if (tsChapter) tsChapter.destroy();
-            tsChapter = new TomSelect('#chapter', {
-                onChange: (value) => {
-                    @this.set('chapter_id', value);
-                }
-            });
-            tsChapter.setValue(@json($chapter_id), true);
+            if (tsChapter) {
+                tsChapter.destroy();
+                tsChapter = null;
+            }
+            const chapterEl = document.getElementById('chapter');
+            if (chapterEl) {
+                tsChapter = new TomSelect('#chapter', {
+                    onChange: (value) => {
+                        @this.set('chapter_id', value);
+                    }
+                });
+                tsChapter.setValue(@json($chapter_id), true);
+            }
 
             if (window.tsTags) window.tsTags.destroy();
             window.tsTags = new TomSelect('#tags', {
@@ -206,8 +214,21 @@
         });
 
         window.addEventListener('chaptersUpdated', e => {
-            if (!tsChapter) return;
-            tsChapter.clearOptions();
+            if (tsChapter) {
+                tsChapter.destroy();
+                tsChapter = null;
+            }
+
+            const chapterEl = document.getElementById('chapter');
+            if (!chapterEl) return;
+
+            chapterEl.options.length = 0;
+            chapterEl.append(new Option('-- Select --', ''));
+            tsChapter = new TomSelect('#chapter', {
+                onChange: (value) => {
+                    @this.set('chapter_id', value);
+                }
+            });
             tsChapter.addOptions(e.detail.chapters);
             tsChapter.refreshOptions(false);
             tsChapter.setValue('');

--- a/resources/views/livewire/admin/questions/edit.blade.php
+++ b/resources/views/livewire/admin/questions/edit.blade.php
@@ -24,15 +24,17 @@
             </div>
 
             {{-- Chapter (Required if Sub-Subject) --}}
-            <div wire:ignore wire:key="chapter-select-{{ $question->id }}">
-                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Chapter</label>
-                <select id="chapter" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
-                    <option value="">-- Select --</option>
-                    @foreach($chapters as $c)
-                        <option value="{{ $c->id }}" @selected($c->id == $chapter_id)>{{ $c->name }}</option>
-                    @endforeach
-                </select>
-            </div>
+            @if($sub_subject_id)
+                <div wire:ignore wire:key="chapter-select-{{ $question->id }}">
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Chapter</label>
+                    <select id="chapter" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
+                        <option value="">-- Select --</option>
+                        @foreach($chapters as $c)
+                            <option value="{{ $c->id }}" @selected($c->id == $chapter_id)>{{ $c->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
+            @endif
         </div>
 
         {{-- Main Question --}}
@@ -175,13 +177,19 @@
             });
             tsSubSubject.setValue(@json($sub_subject_id), true);
 
-            if (tsChapter) tsChapter.destroy();
-            tsChapter = new TomSelect('#chapter', {
-                onChange: (value) => {
-                    @this.set('chapter_id', value);
-                }
-            });
-            tsChapter.setValue(@json($chapter_id), true);
+            if (tsChapter) {
+                tsChapter.destroy();
+                tsChapter = null;
+            }
+            const chapterEl = document.getElementById('chapter');
+            if (chapterEl) {
+                tsChapter = new TomSelect('#chapter', {
+                    onChange: (value) => {
+                        @this.set('chapter_id', value);
+                    }
+                });
+                tsChapter.setValue(@json($chapter_id), true);
+            }
 
             if (window.tsTags) window.tsTags.destroy();
             window.tsTags = new TomSelect('#tags', {
@@ -205,8 +213,21 @@
         });
 
         window.addEventListener('chaptersUpdated', e => {
-            if (!tsChapter) return;
-            tsChapter.clearOptions();
+            if (tsChapter) {
+                tsChapter.destroy();
+                tsChapter = null;
+            }
+
+            const chapterEl = document.getElementById('chapter');
+            if (!chapterEl) return;
+
+            chapterEl.options.length = 0;
+            chapterEl.append(new Option('-- Select --', ''));
+            tsChapter = new TomSelect('#chapter', {
+                onChange: (value) => {
+                    @this.set('chapter_id', value);
+                }
+            });
             tsChapter.addOptions(e.detail.chapters);
             tsChapter.refreshOptions(false);
             tsChapter.setValue('');


### PR DESCRIPTION
## Summary
- Hide chapter dropdown unless a sub-subject is selected on question forms
- Reinitialize chapter selector via JS when sub-subject changes
- Clear chapter list when sub-subject is removed

## Testing
- `php artisan test` *(fails: require vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68c479680d848326aa374b06cdd62e01