### PR TITLE
feat: support sub-subject-driven chapter selection

### DIFF
--- a/resources/views/livewire/admin/questions/question-form.blade.php
+++ b/resources/views/livewire/admin/questions/question-form.blade.php
@@ -11,10 +11,21 @@
             </select>
         </div>
 
+        {{-- Sub-Subject (Optional) --}}
+        <div>
+            <label>Sub-Subject (Optional)</label>
+            <select wire:model="sub_subject_id" class="border p-2 rounded w-full">
+                <option value="">-- Select --</option>
+                @foreach($subSubjects as $ss)
+                    <option value="{{ $ss->id }}">{{ $ss->name }}</option>
+                @endforeach
+            </select>
+        </div>
+
         {{-- Chapter (Optional) --}}
         <div>
             <label>Chapter (Optional)</label>
-            <select wire:model="chapter_id" class="border p-2 rounded w-full">
+            <select wire:model="chapter_id" class="border p-2 rounded w-full" {{ $sub_subject_id ? '' : 'disabled' }}>
                 <option value="">-- Select --</option>
                 @foreach($chapters as $c)
                     <option value="{{ $c->id }}">{{ $c->name }}</option>


### PR DESCRIPTION
## Summary
- add sub-subject field to question form
- dynamically load chapters when a sub-subject is chosen

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c47c04fd248326a8692858b69f7867