### PR TITLE
Fix CKEditor selection restore for job description images

### DIFF
--- a/resources/views/livewire/admin/jobs/create.blade.php
+++ b/resources/views/livewire/admin/jobs/create.blade.php
@@ -115,7 +115,15 @@
             editor.addCommand('openMediaModal', {
                 exec: function () {
                     imageToReplace = null;
-                    savedSelection = editor.getSelection().getRanges()[0];
+                    // Clone the current selection range so it can be restored
+                    // after the media modal closes. Without cloning, the
+                    // reference becomes stale once focus shifts away from the
+                    // editor, preventing images from being inserted at the
+                    // expected position.
+                    const ranges = editor.getSelection().getRanges();
+                    if (ranges.length) {
+                        savedSelection = ranges[0].clone();
+                    }
                     window.dispatchEvent(new CustomEvent('open-media-modal'));
                 }
             });


### PR DESCRIPTION
## Summary
- Clone CKEditor selection before opening media modal and restore range so images insert at correct position

## Testing
- `composer test` *(fails: Script @php artisan config:clear --ansi handling the test event returned with error code 255)*
- `composer install` *(fails: require GitHub token, 403 CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c52f800af083268e68d85d9db6fa64