### PR TITLE
Fix missing CKEditor selection when inserting images

### DIFF
--- a/resources/views/livewire/admin/jobs/create.blade.php
+++ b/resources/views/livewire/admin/jobs/create.blade.php
@@ -120,7 +120,8 @@
                     // reference becomes stale once focus shifts away from the
                     // editor, preventing images from being inserted at the
                     // expected position.
-                    const ranges = editor.getSelection().getRanges();
+                    const selection = editor.getSelection();
+                    const ranges = selection ? selection.getRanges() : [];
                     if (ranges.length) {
                         savedSelection = ranges[0].clone();
                     }


### PR DESCRIPTION
## Summary
- Guard against missing selections before saving CKEditor range for image insertion

## Testing
- `composer test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: GitHub API 403, missing token)*

------
https://chatgpt.com/codex/tasks/task_e_68c53170c8b08326b1131b71e3189c51