### PR TITLE
fix: restore CKEditor cursor for image insertion

### DIFF
--- a/resources/views/livewire/admin/jobs/create.blade.php
+++ b/resources/views/livewire/admin/jobs/create.blade.php
@@ -112,19 +112,20 @@
                 @this.set('description', editor.getData(), false);
             });
 
+            // Preserve the current cursor position so images can be
+            // inserted where the user expects even after the editor
+            // loses focus when the media modal is opened.
+            editor.on('selectionChange', function () {
+                const selection = editor.getSelection();
+                const ranges = selection ? selection.getRanges() : [];
+                if (ranges.length) {
+                    savedSelection = ranges[0].clone();
+                }
+            });
+
             editor.addCommand('openMediaModal', {
                 exec: function () {
                     imageToReplace = null;
-                    // Clone the current selection range so it can be restored
-                    // after the media modal closes. Without cloning, the
-                    // reference becomes stale once focus shifts away from the
-                    // editor, preventing images from being inserted at the
-                    // expected position.
-                    const selection = editor.getSelection();
-                    const ranges = selection ? selection.getRanges() : [];
-                    if (ranges.length) {
-                        savedSelection = ranges[0].clone();
-                    }
                     window.dispatchEvent(new CustomEvent('open-media-modal'));
                 }
             });


### PR DESCRIPTION
## Summary
- ensure CKEditor saves and restores cursor so chosen images insert at expected position

## Testing
- `composer test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: CONNECT tunnel failed when downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c5347ae4a083269e7e0a81abe5c67e