### PR TITLE
Fix CKEditor image insertion

### DIFF
--- a/resources/views/livewire/admin/jobs/create.blade.php
+++ b/resources/views/livewire/admin/jobs/create.blade.php
@@ -105,7 +105,8 @@
                     { name: 'links', items: ['Link', 'Unlink'] },
                     { name: 'insert', items: ['ImageManager'] },
                     { name: 'tools', items: ['Source'] }
-                ]
+                ],
+                allowedContent: true
             });
 
             editor.on('change', function () {


### PR DESCRIPTION
## Summary
- allow CKEditor to render inserted images by disabling ACF restrictions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68c55205cf8883268cec9dabcc3529d5