### PR TITLE
Redesign job post create/update layout

### DIFF
--- a/resources/views/livewire/admin/jobs/create.blade.php
+++ b/resources/views/livewire/admin/jobs/create.blade.php
@@ -1,62 +1,48 @@
 <div class="max-w-7xl mx-auto">
-    <form wire:submit.prevent="save" class="grid grid-cols-1 gap-6 lg:grid-cols-3">
-        <div class="col-span-1 bg-white dark:bg-gray-800 p-6 rounded-lg shadow space-y-4">
-            <div>
-                <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Title</label>
-                <input type="text" wire:model="title" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
-            </div>
-            <div>
-                <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Slug</label>
-                <input type="text" wire:model="slug" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
-            </div>
-            <div>
-                <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Summary</label>
-                <textarea wire:model="summary" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200"></textarea>
-            </div>
-            <div>
-                <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Description</label>
-                <div wire:ignore>
-                    <textarea wire:model="description" id="content" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200"></textarea>
+    <form wire:submit.prevent="save" class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div class="lg:col-span-2 space-y-6">
+            <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow space-y-4">
+                <div>
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Title</label>
+                    <input type="text" wire:model="title" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
+                </div>
+                <div>
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Slug</label>
+                    <input type="text" wire:model="slug" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
+                </div>
+                <div>
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Summary</label>
+                    <textarea wire:model="summary" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200"></textarea>
+                </div>
+                <div>
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Description</label>
+                    <div wire:ignore>
+                        <textarea wire:model="description" id="content" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200"></textarea>
+                    </div>
+                </div>
+                <div class="flex items-center">
+                    <input type="checkbox" wire:model="featured" id="featured" class="mr-2" />
+                    <label for="featured" class="text-sm text-gray-700 dark:text-gray-200">Is Featured?</label>
                 </div>
             </div>
-            <div>
-                <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">SEO Title</label>
-                <input type="text" wire:model="seo_title" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
-            </div>
-            <div>
-                <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">SEO Description</label>
-                <textarea wire:model="seo_description" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200"></textarea>
-            </div>
-            <div>
-                <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">SEO Keywords</label>
-                <input type="text" wire:model="seo_keywords" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
+            <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow space-y-4">
+                <h2 class="text-lg font-medium text-gray-700 dark:text-gray-200">SEO Settings</h2>
+                <div>
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Meta Title</label>
+                    <input type="text" wire:model="seo_title" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
+                </div>
+                <div>
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Meta Description</label>
+                    <textarea wire:model="seo_description" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200"></textarea>
+                </div>
+                <div>
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Meta Keywords</label>
+                    <input type="text" wire:model="seo_keywords" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
+                </div>
             </div>
         </div>
-        <div class="col-span-1 lg:col-span-2 bg-white dark:bg-gray-800 p-6 rounded-lg shadow space-y-4">
-            <div>
-                <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Category</label>
-                <select wire:model="category_id" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200">
-                    <option value="">Select category</option>
-                    @foreach($categories as $category)
-                        <option value="{{ $category->id }}">{{ $category->name }}</option>
-                    @endforeach
-                </select>
-            </div>
-            <div>
-                <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Company Name</label>
-                <input type="text" wire:model="company_name" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
-            </div>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Deadline</label>
-                    <input type="date" wire:model="deadline" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
-                </div>
-                <div>
-                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Posted At</label>
-                    <input type="datetime-local" wire:model="posted_at" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
-                </div>
-            </div>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="space-y-6">
+            <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow space-y-4">
                 <div>
                     <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Status</label>
                     <select wire:model="status" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200">
@@ -65,24 +51,41 @@
                         @endforeach
                     </select>
                 </div>
-                <div class="flex items-center md:mt-6">
-                    <input type="checkbox" wire:model="featured" id="featured" class="mr-2" />
-                    <label for="featured" class="text-sm text-gray-700 dark:text-gray-200">Featured</label>
+                <div>
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Category</label>
+                    <select wire:model="category_id" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200">
+                        <option value="">Select category</option>
+                        @foreach($categories as $category)
+                            <option value="{{ $category->id }}">{{ $category->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div>
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Company Name</label>
+                    <input type="text" wire:model="company_name" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
+                </div>
+                <div>
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Deadline</label>
+                    <input type="date" wire:model="deadline" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
+                </div>
+                <div>
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Posted At</label>
+                    <input type="datetime-local" wire:model="posted_at" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
+                </div>
+                <div x-data="{ imageUrl: @entangle('cover_image') }">
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Featured Image</label>
+                    <div x-show="!imageUrl" @click="window.selectingThumbnail = true; window.dispatchEvent(new CustomEvent('open-media-modal'))" class="border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-10 text-center cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700">
+                        <p class="text-gray-500 dark:text-gray-400">Select Image</p>
+                    </div>
+                    <div x-show="imageUrl" class="space-y-2">
+                        <img :src="imageUrl" class="h-32 w-32 object-cover rounded" />
+                        <button type="button" @click="imageUrl = null" class="px-3 py-1 bg-red-600 text-white rounded">Remove</button>
+                    </div>
+                </div>
+                <div class="text-right">
+                    <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded">Save</button>
                 </div>
             </div>
-            <div x-data="{ imageUrl: @entangle('cover_image') }">
-                <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Thumbnail</label>
-                <div x-show="!imageUrl" @click="window.selectingThumbnail = true; window.dispatchEvent(new CustomEvent('open-media-modal'))" class="border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-10 text-center cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700">
-                    <p class="text-gray-500 dark:text-gray-400">Select Thumbnail</p>
-                </div>
-                <div x-show="imageUrl" class="space-y-2">
-                    <img :src="imageUrl" class="h-32 w-32 object-cover rounded" />
-                    <button type="button" @click="imageUrl = null" class="px-3 py-1 bg-red-600 text-white rounded">Remove</button>
-                </div>
-            </div>
-        </div>
-        <div class="col-span-1 lg:col-span-3 text-right">
-            <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded">Save</button>
         </div>
     </form>
 

--- a/resources/views/livewire/admin/jobs/edit.blade.php
+++ b/resources/views/livewire/admin/jobs/edit.blade.php
@@ -1,63 +1,49 @@
 <div class="max-w-7xl mx-auto">
-    <form wire:submit.prevent="update" class="grid grid-cols-1 gap-6 lg:grid-cols-3">
-        <div class="col-span-1 bg-white dark:bg-gray-800 p-6 rounded-lg shadow space-y-4">
-            <div>
-                <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Title</label>
-                <input type="text" wire:model="title" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
-            </div>
-            <div>
-                <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Slug</label>
-                <input type="text" wire:model="slug" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
-            </div>
-            <div>
-                <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Summary</label>
-                <textarea wire:model="summary" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200"></textarea>
-            </div>
-            <div>
-                <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Description</label>
-                <div wire:ignore>
-                    <div id="description-editor" class="w-full border rounded-md dark:border-gray-600 min-h-[250px]"></div>
+    <form wire:submit.prevent="update" class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div class="lg:col-span-2 space-y-6">
+            <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow space-y-4">
+                <div>
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Title</label>
+                    <input type="text" wire:model="title" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
                 </div>
-                <textarea wire:model="description" class="hidden"></textarea>
+                <div>
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Slug</label>
+                    <input type="text" wire:model="slug" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
+                </div>
+                <div>
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Summary</label>
+                    <textarea wire:model="summary" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200"></textarea>
+                </div>
+                <div>
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Description</label>
+                    <div wire:ignore>
+                        <div id="description-editor" class="w-full border rounded-md dark:border-gray-600 min-h-[250px]"></div>
+                    </div>
+                    <textarea wire:model="description" class="hidden"></textarea>
+                </div>
+                <div class="flex items-center">
+                    <input type="checkbox" wire:model="featured" id="featured" class="mr-2" />
+                    <label for="featured" class="text-sm text-gray-700 dark:text-gray-200">Is Featured?</label>
+                </div>
             </div>
-            <div>
-                <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">SEO Title</label>
-                <input type="text" wire:model="seo_title" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
-            </div>
-            <div>
-                <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">SEO Description</label>
-                <textarea wire:model="seo_description" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200"></textarea>
-            </div>
-            <div>
-                <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">SEO Keywords</label>
-                <input type="text" wire:model="seo_keywords" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
+            <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow space-y-4">
+                <h2 class="text-lg font-medium text-gray-700 dark:text-gray-200">SEO Settings</h2>
+                <div>
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Meta Title</label>
+                    <input type="text" wire:model="seo_title" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
+                </div>
+                <div>
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Meta Description</label>
+                    <textarea wire:model="seo_description" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200"></textarea>
+                </div>
+                <div>
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Meta Keywords</label>
+                    <input type="text" wire:model="seo_keywords" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
+                </div>
             </div>
         </div>
-        <div class="col-span-1 lg:col-span-2 bg-white dark:bg-gray-800 p-6 rounded-lg shadow space-y-4">
-            <div>
-                <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Category</label>
-                <select wire:model="category_id" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200">
-                    <option value="">Select category</option>
-                    @foreach($categories as $category)
-                        <option value="{{ $category->id }}">{{ $category->name }}</option>
-                    @endforeach
-                </select>
-            </div>
-            <div>
-                <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Company Name</label>
-                <input type="text" wire:model="company_name" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
-            </div>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Deadline</label>
-                    <input type="date" wire:model="deadline" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
-                </div>
-                <div>
-                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Posted At</label>
-                    <input type="datetime-local" wire:model="posted_at" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
-                </div>
-            </div>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="space-y-6">
+            <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow space-y-4">
                 <div>
                     <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Status</label>
                     <select wire:model="status" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200">
@@ -66,24 +52,41 @@
                         @endforeach
                     </select>
                 </div>
-                <div class="flex items-center md:mt-6">
-                    <input type="checkbox" wire:model="featured" id="featured" class="mr-2" />
-                    <label for="featured" class="text-sm text-gray-700 dark:text-gray-200">Featured</label>
+                <div>
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Category</label>
+                    <select wire:model="category_id" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200">
+                        <option value="">Select category</option>
+                        @foreach($categories as $category)
+                            <option value="{{ $category->id }}">{{ $category->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div>
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Company Name</label>
+                    <input type="text" wire:model="company_name" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
+                </div>
+                <div>
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Deadline</label>
+                    <input type="date" wire:model="deadline" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
+                </div>
+                <div>
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Posted At</label>
+                    <input type="datetime-local" wire:model="posted_at" class="w-full px-3 py-2 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200" />
+                </div>
+                <div x-data="{ imageUrl: @entangle('cover_image') }">
+                    <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Featured Image</label>
+                    <div x-show="!imageUrl" @click="window.selectingThumbnail = true; window.dispatchEvent(new CustomEvent('open-media-modal'))" class="border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-10 text-center cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700">
+                        <p class="text-gray-500 dark:text-gray-400">Select Image</p>
+                    </div>
+                    <div x-show="imageUrl" class="space-y-2">
+                        <img :src="imageUrl" class="h-32 w-32 object-cover rounded" />
+                        <button type="button" @click="imageUrl = null" class="px-3 py-1 bg-red-600 text-white rounded">Remove</button>
+                    </div>
+                </div>
+                <div class="text-right">
+                    <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded">Update</button>
                 </div>
             </div>
-            <div x-data="{ imageUrl: @entangle('cover_image') }">
-                <label class="block mb-1 text-sm font-medium text-gray-700 dark:text-gray-200">Thumbnail</label>
-                <div x-show="!imageUrl" @click="window.selectingThumbnail = true; window.dispatchEvent(new CustomEvent('open-media-modal'))" class="border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-10 text-center cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700">
-                    <p class="text-gray-500 dark:text-gray-400">Select Thumbnail</p>
-                </div>
-                <div x-show="imageUrl" class="space-y-2">
-                    <img :src="imageUrl" class="h-32 w-32 object-cover rounded" />
-                    <button type="button" @click="imageUrl = null" class="px-3 py-1 bg-red-600 text-white rounded">Remove</button>
-                </div>
-            </div>
-        </div>
-        <div class="col-span-1 lg:col-span-3 text-right">
-            <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded">Update</button>
         </div>
     </form>
 


### PR DESCRIPTION
## Summary
- Rework job post create/edit templates to use two-column layout
- Add dedicated SEO settings panel and featured toggle
- Consolidate publish controls (status, category, company info, schedule, image) in sidebar

## Testing
- `phpunit` *(fails: command not found)*
- `php artisan test` *(fails: vendor autoload missing)*
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68c59c6830c48326bb3289acc12a6126