### PR TITLE
Fix job company validation rule

### DIFF
--- a/app/Livewire/Admin/Jobs/Edit.php
+++ b/app/Livewire/Admin/Jobs/Edit.php
@@ -56,7 +56,7 @@ class Edit extends Component
             'title' => 'required|string|max:255',
             'slug' => 'required|string|max:255|unique:job_posts,slug,' . $this->job->id,
             'category_id' => 'nullable|exists:job_categories,id',
-            'company_id' => 'nullable|exists:job_companies, id',
+            'company_id' => 'nullable|exists:job_companies,id',
             'summary' => 'nullable|string|max:255',
             'description' => 'nullable|string',
             'deadline' => 'nullable|date',


### PR DESCRIPTION
## Summary
- remove stray space in job company validation rule

## Testing
- `php artisan test` *(fails: Failed to open stream: No such file or directory)*
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c61c1f3ff88326bf9e27a1b0ca7f3c