### PR TITLE
Load MathJax globally in all layouts

### DIFF
--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -54,17 +54,14 @@
             }
         });
     </script>
+    {{-- MathJax Configuration --}}
+    <script>
+        window.MathJax = {
+            tex: { inlineMath: [['$', '$'], ['\\(', '\\)']] },
+            svg: { fontCache: 'global' }
+        };
+    </script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
-    {{-- MathJax Configuration (যদি MathJax ব্যবহার করেন) --}}
-    @if(isset($usesMath) && $usesMath)
-        <script>
-            window.MathJax = {
-                tex: { inlineMath: [['$', '$'], ['\\(', '\\)']] },
-                svg: { fontCache: 'global' }
-            };
-        </script>
-        <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"></script>
-    @endif
 
     {{-- নির্দিষ্ট পেজের জন্য কোনো স্ক্রিপ্ট থাকলে এখানে পুশ হবে --}}
     @stack('scripts')

--- a/resources/views/layouts/frontend.blade.php
+++ b/resources/views/layouts/frontend.blade.php
@@ -28,5 +28,13 @@
     <footer class="bg-white border-t mt-12 py-6 text-center text-sm text-gray-500">
         &copy; {{ date('Y') }} MCQ Bank. All rights reserved.
     </footer>
+    {{-- MathJax Configuration --}}
+    <script>
+        window.MathJax = {
+            tex: { inlineMath: [['$', '$'], ['\\(', '\\)']] },
+            svg: { fontCache: 'global' }
+        };
+    </script>
+    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -26,5 +26,13 @@
                 {{ $slot }}
             </div>
         </div>
+        {{-- MathJax Configuration --}}
+        <script>
+            window.MathJax = {
+                tex: { inlineMath: [['$', '$'], ['\\(', '\\)']] },
+                svg: { fontCache: 'global' }
+            };
+        </script>
+        <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     </body>
 </html>

--- a/resources/views/layouts/panel.blade.php
+++ b/resources/views/layouts/panel.blade.php
@@ -239,17 +239,15 @@
 
 {{-- ✅ Livewire Scripts --}}
 @livewireScripts
+
+{{-- MathJax Configuration --}}
+<script>
+    window.MathJax = {
+        tex: { inlineMath: [['$', '$'], ['\\(', '\\)']] },
+        svg: { fontCache: 'global' }
+    };
+</script>
 <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
-{{-- MathJax Configuration (যদি MathJax ব্যবহার করেন) --}}
-@if(isset($usesMath) && $usesMath)
-    <script>
-        window.MathJax = {
-            tex: { inlineMath: [['$', '$'], ['\\(', '\\)']] },
-            svg: { fontCache: 'global' }
-        };
-    </script>
-    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"></script>
-@endif
 
 {{-- ✅ Extra scripts --}}
 @stack('scripts')


### PR DESCRIPTION
## Summary
- configure MathJax globally in admin and panel layouts
- include MathJax setup in frontend and guest layouts

## Testing
- `composer test` *(fails: require(/workspace/laravel-livewire-question-bank-project/vendor/autoload.php): Failed to open stream)*
- `composer install` *(fails: curl error 56 while downloading https://api.github.com/repos/symfony/polyfill-php80/zipball/...: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b36b79788326ab16a6d3d0a27835