### PR TITLE
Ensure MathJax renders after Livewire updates

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -171,7 +171,23 @@ function initializeApp() {
     attachFormulaClickHandler();
 }
 
+// --- MathJax re-render helper ---
+function renderMath() {
+    if (window.MathJax && typeof window.MathJax.typesetPromise === 'function') {
+        window.MathJax.typesetPromise();
+    }
+}
+
 // Initial page load
-document.addEventListener('DOMContentLoaded', initializeApp);
+document.addEventListener('DOMContentLoaded', () => {
+    initializeApp();
+    renderMath();
+});
 // After every Livewire navigation
-document.addEventListener('livewire:navigated', initializeApp);
+document.addEventListener('livewire:navigated', () => {
+    initializeApp();
+    renderMath();
+});
+
+// When Livewire updates existing DOM
+document.addEventListener('livewire:update', renderMath);


### PR DESCRIPTION
## Summary
- Re-render MathJax on DOM load, Livewire navigation, and updates
- Provide a reusable helper to trigger MathJax typesetting globally

## Testing
- `npm run build`
- `composer test` *(fails: require(/workspace/laravel-livewire-question-bank-project/vendor/autoload.php): No such file or directory)*
- `composer install` *(fails: Proxy CONNECT aborted / GitHub 403; requires token)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b52c3c2c8326973c2db834489ca9