### PR TITLE
Add student exam system with practice navigation

### DIFF
--- a/resources/views/livewire/admin/partials/sidebar.blade.php
+++ b/resources/views/livewire/admin/partials/sidebar.blade.php
@@ -83,6 +83,17 @@
                 <x-heroicon-o-question-mark-circle class="w-5 h-5"/>
                 <span class="sidebar-text">Questions</span>
             </a>
+        @elseif(auth()->user()->isStudent())
+            <a wire:navigate href="{{ route('student.exam') }}"
+               class="nav-link flex items-center gap-3 px-4 py-2.5 rounded-lg {{ request()->is('student/exam') ? 'bg-indigo-50 dark:bg-gray-700 text-indigo-600 dark:text-indigo-400 font-semibold' : '' }}">
+                <x-heroicon-o-clipboard-document-check class="w-5 h-5"/>
+                <span class="sidebar-text">Exam</span>
+            </a>
+            <a wire:navigate href="{{ route('practice') }}"
+               class="nav-link flex items-center gap-3 px-4 py-2.5 rounded-lg {{ request()->routeIs('practice') ? 'bg-indigo-50 dark:bg-gray-700 text-indigo-600 dark:text-indigo-400 font-semibold' : '' }}">
+                <x-heroicon-o-pencil-square class="w-5 h-5"/>
+                <span class="sidebar-text">Daily Practice</span>
+            </a>
         @endif
 
         @if(auth()->user()->isAdmin())

--- a/resources/views/livewire/student/exam.blade.php
+++ b/resources/views/livewire/student/exam.blade.php
@@ -1,0 +1,58 @@
+<div wire:poll.1s="tick" class="space-y-6">
+    @if(!$examStarted && !$examFinished)
+        <div class="max-w-md mx-auto bg-white dark:bg-gray-800 p-6 rounded shadow space-y-4">
+            <select wire:model="subjectId" class="w-full border rounded px-3 py-2">
+                <option value="">বিষয় সিলেক্ট করো</option>
+                @foreach($subjects as $subject)
+                    <option value="{{ $subject->id }}">{{ $subject->name }}</option>
+                @endforeach
+            </select>
+
+            <select wire:model="chapterId" class="w-full border rounded px-3 py-2">
+                <option value="">অধ্যায় সিলেক্ট করো</option>
+                @foreach($chapters as $chapter)
+                    <option value="{{ $chapter->id }}">{{ $chapter->name }}</option>
+                @endforeach
+            </select>
+
+            <input type="number" wire:model="totalQuestions" class="w-full border rounded px-3 py-2" />
+            <input type="number" wire:model="duration" class="w-full border rounded px-3 py-2" />
+
+            <button wire:click="startExam" class="w-full bg-indigo-500 text-white py-2 rounded">পরীক্ষা শুরু করো</button>
+        </div>
+    @elseif($examStarted)
+        <div class="max-w-2xl mx-auto bg-white dark:bg-gray-800 p-6 rounded shadow">
+            <div class="flex justify-between mb-4">
+                <div>প্রশ্ন {{ $currentIndex + 1 }} / {{ $questions->count() }}</div>
+                <div>সময়: {{ gmdate('i:s', $timeLeft) }}</div>
+            </div>
+
+            <div class="mb-4 prose max-w-none">{!! $currentQuestion->title !!}</div>
+
+            <ul class="space-y-2">
+                @foreach($currentQuestion->options as $opt)
+                    <li>
+                        <button wire:click="selectOption({{ $opt->id }})" class="border px-3 py-2 rounded w-full text-left @if($selectedOption == $opt->id) bg-indigo-100 @endif">
+                            {!! $opt->option_text !!}
+                        </button>
+                    </li>
+                @endforeach
+            </ul>
+
+            <div class="mt-4">
+                <button wire:click="next" class="bg-blue-500 text-white px-4 py-2 rounded" @disabled(!$selectedOption)>Next</button>
+            </div>
+
+            <script>
+                document.addEventListener('livewire:update', () => {
+                    if (window.MathJax) MathJax.typesetPromise();
+                });
+            </script>
+        </div>
+    @elseif($examFinished)
+        <div class="max-w-md mx-auto bg-white dark:bg-gray-800 p-6 rounded shadow text-center space-y-4">
+            <div class="text-2xl font-semibold">তোমার স্কোর: {{ $score }} / {{ $questions->count() }}</div>
+            <button wire:click="resetExam" class="bg-indigo-500 text-white px-4 py-2 rounded">নতুন পরীক্ষা</button>
+        </div>
+    @endif
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,6 +31,7 @@ use App\Livewire\Admin\JobCompanies\Edit as JobCompanyEdit;
 use App\Livewire\Admin\Media\Index as MediaIndex;
 use App\Livewire\Teacher\Dashboard as TeacherDashboard;
 use App\Livewire\Student\Dashboard as StudentDashboard;
+use App\Livewire\Student\Exam as StudentExam;
 use App\Livewire\Practice;
 use App\Http\Controllers\ImageController;
 use App\Http\Controllers\MediaController;
@@ -96,6 +97,7 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
 
 Route::middleware(['auth', 'role:student'])->group(function () {
     Route::get('/student/dashboard', StudentDashboard::class)->name('student.dashboard');
+    Route::get('/student/exam', StudentExam::class)->name('student.exam');
 });
 
 Route::middleware(['auth', 'role:teacher,student'])->group(function () {


### PR DESCRIPTION
## Summary
- add Livewire-based exam component for students with subject, chapter, question count, and timed sessions
- expose student exam route and add sidebar links for exam and daily practice

## Testing
- `php artisan test` *(fails: require(/workspace/laravel-livewire-question-bank-project/vendor/autoload.php): Failed to open stream)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c70c3a9ed48326b16e113187965809