### PR TITLE
Implement role selection onboarding and teacher profile requirements

### DIFF
--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -57,6 +57,7 @@ class SocialiteController
                 'email' => $socialUser->getEmail(),
                 'password' => Hash::make(Str::random(16)),
                 'role' => Role::STUDENT,
+                'role_confirmed_at' => now(),
                 'email_verified_at' => now(),
                 'avatar_url' => $socialUser->getAvatar(),
             ]);

--- a/app/Livewire/Auth/RolePrompt.php
+++ b/app/Livewire/Auth/RolePrompt.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace App\Livewire\Auth;
+
+use App\Enums\Role;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
+use Livewire\Component;
+
+class RolePrompt extends Component
+{
+    public ?string $selectedRole = null;
+
+    public bool $showRoleModal = false;
+    public bool $showTeacherForm = false;
+
+    public string $department = '';
+    public string $district = '';
+    public string $upazila = '';
+    public string $phone = '';
+    public string $address = '';
+
+    public function mount(): void
+    {
+        $this->syncState();
+    }
+
+    public function submitRole(): void
+    {
+        $this->validate([
+            'selectedRole' => ['required', Rule::in([Role::TEACHER->value, Role::STUDENT->value])],
+        ]);
+
+        $user = $this->currentUser();
+
+        if (! $user) {
+            return;
+        }
+
+        $role = Role::from($this->selectedRole);
+
+        $payload = [
+            'role' => $role,
+            'role_confirmed_at' => now(),
+        ];
+
+        if ($role === Role::STUDENT) {
+            $payload['teacher_profile_completed_at'] = null;
+        }
+
+        $user->forceFill($payload)->save();
+        $user->refresh();
+
+        $this->showRoleModal = false;
+
+        if ($role === Role::TEACHER && ! $this->teacherProfileComplete($user)) {
+            $this->fillTeacherFields($user);
+            $this->showTeacherForm = true;
+        } else {
+            $this->resetTeacherFields();
+            $this->showTeacherForm = false;
+        }
+    }
+
+    public function submitTeacherForm(): void
+    {
+        $this->validate([
+            'department' => ['required', 'string', 'max:255'],
+            'district' => ['required', 'string', 'max:255'],
+            'upazila' => ['required', 'string', 'max:255'],
+            'phone' => ['required', 'string', 'max:30'],
+            'address' => ['required', 'string', 'max:1000'],
+        ]);
+
+        $user = $this->currentUser();
+
+        if (! $user) {
+            return;
+        }
+
+        $user->forceFill([
+            'department' => $this->department,
+            'district' => $this->district,
+            'upazila' => $this->upazila,
+            'phone' => $this->phone,
+            'address' => $this->address,
+            'teacher_profile_completed_at' => now(),
+        ])->save();
+
+        $user->refresh();
+        $this->resetTeacherFields();
+        $this->showTeacherForm = false;
+    }
+
+    public function render()
+    {
+        return view('livewire.auth.role-prompt');
+    }
+
+    protected function syncState(): void
+    {
+        $user = $this->currentUser();
+
+        if (! $user || $user->role === Role::ADMIN) {
+            $this->showRoleModal = false;
+            $this->showTeacherForm = false;
+            return;
+        }
+
+        $needsRoleConfirmation = $user->role_confirmed_at === null;
+        $needsTeacherDetails = $user->role === Role::TEACHER && ! $this->teacherProfileComplete($user);
+
+        $this->showRoleModal = $needsRoleConfirmation;
+        $this->showTeacherForm = ! $needsRoleConfirmation && $needsTeacherDetails;
+
+        $this->selectedRole = $needsRoleConfirmation ? null : $user->role?->value;
+
+        if ($needsTeacherDetails) {
+            $this->fillTeacherFields($user);
+        } else {
+            $this->resetTeacherFields();
+        }
+    }
+
+    protected function fillTeacherFields(User $user): void
+    {
+        $this->department = (string) ($user->department ?? '');
+        $this->district = (string) ($user->district ?? '');
+        $this->upazila = (string) ($user->upazila ?? '');
+        $this->phone = (string) ($user->phone ?? '');
+        $this->address = (string) ($user->address ?? '');
+    }
+
+    protected function resetTeacherFields(): void
+    {
+        $this->department = '';
+        $this->district = '';
+        $this->upazila = '';
+        $this->phone = '';
+        $this->address = '';
+    }
+
+    protected function teacherProfileComplete(User $user): bool
+    {
+        return ! empty($user->department)
+            && ! empty($user->district)
+            && ! empty($user->upazila)
+            && ! empty($user->phone)
+            && ! empty($user->address)
+            && ! empty($user->teacher_profile_completed_at);
+    }
+
+    protected function currentUser(): ?User
+    {
+        $user = Auth::user();
+
+        return $user instanceof User ? $user : null;
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -27,6 +27,13 @@ class User extends Authenticatable
         'password',
         'role',
         'avatar_url',
+        'department',
+        'district',
+        'upazila',
+        'phone',
+        'address',
+        'role_confirmed_at',
+        'teacher_profile_completed_at',
     ];
 
     /**
@@ -50,6 +57,8 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
             'role' => Role::class,
+            'role_confirmed_at' => 'datetime',
+            'teacher_profile_completed_at' => 'datetime',
         ];
     }
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -31,6 +31,7 @@ class UserFactory extends Factory
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
             'role' => Role::STUDENT,
+            'role_confirmed_at' => now(),
         ];
     }
 

--- a/database/migrations/2025_08_27_000001_add_teacher_onboarding_fields_to_users_table.php
+++ b/database/migrations/2025_08_27_000001_add_teacher_onboarding_fields_to_users_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\\Database\\Migrations\\Migration;
+use Illuminate\\Database\\Schema\\Blueprint;
+use Illuminate\\Support\\Facades\\DB;
+use Illuminate\\Support\\Facades\\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('role_confirmed_at')->nullable()->after('role');
+            $table->string('department')->nullable()->after('avatar_url');
+            $table->string('district')->nullable()->after('department');
+            $table->string('upazila')->nullable()->after('district');
+            $table->string('phone')->nullable()->after('upazila');
+            $table->text('address')->nullable()->after('phone');
+            $table->timestamp('teacher_profile_completed_at')->nullable()->after('address');
+        });
+
+        DB::table('users')->whereNull('role_confirmed_at')->update([
+            'role_confirmed_at' => now(),
+        ]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn([
+                'role_confirmed_at',
+                'department',
+                'district',
+                'upazila',
+                'phone',
+                'address',
+                'teacher_profile_completed_at',
+            ]);
+        });
+    }
+};

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -31,6 +31,7 @@
         <div id="sidebar-overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden z-40 md:hidden"></div>
     </div>
     @auth
+        <livewire:auth.role-prompt />
         <livewire:chat-popup />
     @endauth
     @livewireScripts

--- a/resources/views/layouts/panel.blade.php
+++ b/resources/views/layouts/panel.blade.php
@@ -33,6 +33,7 @@
 
 {{-- ✅ Scripts --}}
 @auth
+    <livewire:auth.role-prompt />
     <livewire:chat-popup />
 @endauth
 <script>

--- a/resources/views/livewire/auth/role-prompt.blade.php
+++ b/resources/views/livewire/auth/role-prompt.blade.php
@@ -1,0 +1,75 @@
+<div>
+    @if ($showRoleModal)
+        <div class="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/80 px-4">
+            <div class="w-full max-w-md rounded-lg bg-white p-6 shadow-xl dark:bg-gray-800">
+                <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100">{{ __('Choose account type') }}</h2>
+                <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+                    {{ __('Please select whether you want to use the platform as a teacher or a student.') }}
+                </p>
+
+                <form wire:submit.prevent="submitRole" class="mt-6 space-y-4">
+                    <label class="flex cursor-pointer items-center gap-3 rounded-lg border p-4 transition hover:border-indigo-500 hover:bg-indigo-50 dark:border-gray-700 dark:hover:border-indigo-400 dark:hover:bg-indigo-500/10">
+                        <input type="radio" wire:model="selectedRole" value="teacher" class="h-4 w-4 text-indigo-600 focus:ring-indigo-500">
+                        <span class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ __('Teacher') }}</span>
+                    </label>
+
+                    <label class="flex cursor-pointer items-center gap-3 rounded-lg border p-4 transition hover:border-indigo-500 hover:bg-indigo-50 dark:border-gray-700 dark:hover:border-indigo-400 dark:hover:bg-indigo-500/10">
+                        <input type="radio" wire:model="selectedRole" value="student" class="h-4 w-4 text-indigo-600 focus:ring-indigo-500">
+                        <span class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ __('Student') }}</span>
+                    </label>
+
+                    <x-input-error :messages="$errors->get('selectedRole')" />
+
+                    <x-primary-button class="w-full justify-center">{{ __('Continue') }}</x-primary-button>
+                </form>
+            </div>
+        </div>
+    @endif
+
+    @if ($showTeacherForm)
+        <div class="fixed inset-0 z-[60] flex items-center justify-center bg-gray-900/80 px-4 py-6">
+            <div class="w-full max-w-3xl overflow-y-auto rounded-lg bg-white p-6 shadow-xl dark:bg-gray-800" style="max-height: 90vh;">
+                <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100">{{ __('Complete teacher profile') }}</h2>
+                <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+                    {{ __('Provide the following information to finish setting up your teacher account.') }}
+                </p>
+
+                <form wire:submit.prevent="submitTeacherForm" class="mt-6 grid grid-cols-1 gap-5 md:grid-cols-2">
+                    <div class="col-span-1">
+                        <x-input-label for="teacher-department" :value="__('Department')" />
+                        <x-text-input id="teacher-department" type="text" wire:model.defer="department" class="mt-1 block w-full" />
+                        <x-input-error :messages="$errors->get('department')" class="mt-2" />
+                    </div>
+
+                    <div class="col-span-1">
+                        <x-input-label for="teacher-district" :value="__('District')" />
+                        <x-text-input id="teacher-district" type="text" wire:model.defer="district" class="mt-1 block w-full" />
+                        <x-input-error :messages="$errors->get('district')" class="mt-2" />
+                    </div>
+
+                    <div class="col-span-1">
+                        <x-input-label for="teacher-upazila" :value="__('Upazila')" />
+                        <x-text-input id="teacher-upazila" type="text" wire:model.defer="upazila" class="mt-1 block w-full" />
+                        <x-input-error :messages="$errors->get('upazila')" class="mt-2" />
+                    </div>
+
+                    <div class="col-span-1">
+                        <x-input-label for="teacher-phone" :value="__('Phone Number')" />
+                        <x-text-input id="teacher-phone" type="text" wire:model.defer="phone" class="mt-1 block w-full" />
+                        <x-input-error :messages="$errors->get('phone')" class="mt-2" />
+                    </div>
+
+                    <div class="col-span-1 md:col-span-2">
+                        <x-input-label for="teacher-address" :value="__('Address')" />
+                        <textarea id="teacher-address" wire:model.defer="address" rows="3" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"></textarea>
+                        <x-input-error :messages="$errors->get('address')" class="mt-2" />
+                    </div>
+
+                    <div class="col-span-1 md:col-span-2 flex justify-end">
+                        <x-primary-button>{{ __('Submit') }}</x-primary-button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/pages/auth/register.blade.php
+++ b/resources/views/livewire/pages/auth/register.blade.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\Role;
 use App\Models\User;
 use App\Models\Setting;
 use Illuminate\Auth\Events\Registered;
@@ -30,6 +31,7 @@ new #[Layout('layouts.guest')] class extends Component
         ]);
 
         $validated['password'] = Hash::make($validated['password']);
+        $validated['role'] = Role::STUDENT;
 
         event(new Registered($user = User::create($validated)));
 


### PR DESCRIPTION
## Summary
- add onboarding columns for users to capture role confirmation and teacher profile details
- introduce a Livewire modal workflow so authenticated users choose a role and teachers must complete their profile
- wire the onboarding flow into registration, social login, authenticated layouts, and the user factory defaults

## Testing
- php artisan test *(fails: composer install requires GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c995b936d8832ea5b97edd11a8419d