### PR TITLE
Adjust registration flow for post-verification role selection

### DIFF
--- a/app/Livewire/Auth/RolePrompt.php
+++ b/app/Livewire/Auth/RolePrompt.php
@@ -34,7 +34,7 @@ class RolePrompt extends Component
 
         $user = $this->currentUser();
 
-        if (! $user) {
+        if (! $user || ! $this->hasVerifiedEmail($user)) {
             return;
         }
 
@@ -75,7 +75,7 @@ class RolePrompt extends Component
 
         $user = $this->currentUser();
 
-        if (! $user) {
+        if (! $user || ! $this->hasVerifiedEmail($user)) {
             return;
         }
 
@@ -103,6 +103,12 @@ class RolePrompt extends Component
         $user = $this->currentUser();
 
         if (! $user || $user->role === Role::ADMIN) {
+            $this->showRoleModal = false;
+            $this->showTeacherForm = false;
+            return;
+        }
+
+        if (! $this->hasVerifiedEmail($user)) {
             $this->showRoleModal = false;
             $this->showTeacherForm = false;
             return;
@@ -156,5 +162,14 @@ class RolePrompt extends Component
         $user = Auth::user();
 
         return $user instanceof User ? $user : null;
+    }
+
+    protected function hasVerifiedEmail(User $user): bool
+    {
+        if (method_exists($user, 'hasVerifiedEmail')) {
+            return $user->hasVerifiedEmail();
+        }
+
+        return (bool) $user->email_verified_at;
     }
 }

--- a/resources/views/livewire/pages/auth/register.blade.php
+++ b/resources/views/livewire/pages/auth/register.blade.php
@@ -7,7 +7,6 @@ use Illuminate\Auth\Events\Registered;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules;
-use Illuminate\Validation\Rule;
 use Livewire\Attributes\Layout;
 use Livewire\Volt\Component;
 
@@ -17,7 +16,6 @@ new #[Layout('layouts.guest')] class extends Component
     public string $email = '';
     public string $password = '';
     public string $password_confirmation = '';
-    public ?string $selectedRole = null;
     public bool $googleLogin = false;
     public bool $facebookLogin = false;
 
@@ -30,22 +28,17 @@ new #[Layout('layouts.guest')] class extends Component
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
             'password' => ['required', 'string', 'confirmed', Rules\Password::defaults()],
-            'selectedRole' => ['required', Rule::in([Role::TEACHER->value, Role::STUDENT->value])],
         ]);
 
         $validated['password'] = Hash::make($validated['password']);
-        $role = Role::from($validated['selectedRole']);
-
-        unset($validated['selectedRole']);
-
-        $validated['role'] = $role;
-        $validated['role_confirmed_at'] = now();
+        $validated['role'] = Role::STUDENT;
+        $validated['role_confirmed_at'] = null;
 
         event(new Registered($user = User::create($validated)));
 
         Auth::login($user);
 
-        $this->redirect(route('dashboard', absolute: false), navigate: true);
+        $this->redirect(route('verification.notice', absolute: false), navigate: true);
     }
 
     public function mount(): void
@@ -115,22 +108,6 @@ new #[Layout('layouts.guest')] class extends Component
                             name="password_confirmation" required autocomplete="new-password" />
 
             <x-input-error :messages="$errors->get('password_confirmation')" class="mt-2" />
-        </div>
-
-        <div class="mt-4">
-            <x-input-label :value="__('Register as')" />
-            <div class="mt-2 space-y-2">
-                <label class="flex cursor-pointer items-center gap-3 rounded-lg border p-4 transition hover:border-indigo-500/50 hover:bg-indigo-50 dark:border-gray-700 dark:hover:border-indigo-400 dark:hover:bg-indigo-500/10">
-                    <input type="radio" wire:model="selectedRole" value="teacher" class="h-4 w-4 text-indigo-600 focus:ring-indigo-500">
-                    <span class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ __('Teacher') }}</span>
-                </label>
-
-                <label class="flex cursor-pointer items-center gap-3 rounded-lg border p-4 transition hover:border-indigo-500/50 hover:bg-indigo-50 dark:border-gray-700 dark:hover:border-indigo-400 dark:hover:bg-indigo-500/10">
-                    <input type="radio" wire:model="selectedRole" value="student" class="h-4 w-4 text-indigo-600 focus:ring-indigo-500">
-                    <span class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ __('Student') }}</span>
-                </label>
-            </div>
-            <x-input-error :messages="$errors->get('selectedRole')" class="mt-2" />
         </div>
 
         <div class="flex items-center justify-end mt-4">

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature\Auth;
 
+use App\Enums\Role;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Volt\Volt;
 use Tests\TestCase;
@@ -29,8 +31,14 @@ class RegistrationTest extends TestCase
 
         $component->call('register');
 
-        $component->assertRedirect(route('dashboard', absolute: false));
+        $component->assertRedirect(route('verification.notice', absolute: false));
 
         $this->assertAuthenticated();
+
+        $user = User::where('email', 'test@example.com')->first();
+
+        $this->assertNotNull($user);
+        $this->assertNull($user->role_confirmed_at);
+        $this->assertEquals(Role::STUDENT, $user->role);
     }
 }


### PR DESCRIPTION
## Summary
- default new email registrations to the student role with an unconfirmed status and send users to the verification notice after signup
- gate the role selection modal and teacher onboarding form until a verified email address is present
- align the registration feature test with the updated post-verification role confirmation flow

## Testing
- php artisan test *(fails: vendor/autoload.php missing because composer install requires GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c9ab685270832e897fda402cae6b0a