### PR TITLE
Prompt role selection for new social logins

### DIFF
--- a/resources/views/auth/social-register.blade.php
+++ b/resources/views/auth/social-register.blade.php
@@ -1,0 +1,72 @@
+<?php
+
+use App\Enums\Role;
+
+?>
+
+<x-guest-layout>
+    <x-auth-session-status class="mb-4" :status="session('status')" />
+
+    <div class="mb-6">
+        <h1 class="text-xl font-semibold text-gray-900">{{ __('Complete your registration') }}</h1>
+        <p class="mt-2 text-sm text-gray-600">
+            {{ __('Welcome back! Please tell us if you are signing up as a student or teacher to finish creating your account.') }}
+        </p>
+    </div>
+
+    <div class="mb-6 space-y-4">
+        <div>
+            <span class="block text-sm font-medium text-gray-700">{{ __('Name') }}</span>
+            <span class="block mt-1 text-gray-900">{{ $name }}</span>
+        </div>
+        <div>
+            <span class="block text-sm font-medium text-gray-700">{{ __('Email') }}</span>
+            <span class="block mt-1 text-gray-900">{{ $email }}</span>
+        </div>
+        <div>
+            <span class="block text-sm font-medium text-gray-700">{{ __('Signing in with') }}</span>
+            <span class="block mt-1 text-gray-900">{{ ucfirst($provider) }}</span>
+        </div>
+    </div>
+
+    <form method="POST" action="{{ route('social.register.complete', ['provider' => $provider]) }}" class="space-y-6">
+        @csrf
+
+        <div>
+            <span class="block text-sm font-medium text-gray-700">{{ __('I am registering as') }}</span>
+            <div class="mt-3 space-y-3">
+                <label class="flex items-center">
+                    <input
+                        type="radio"
+                        name="role"
+                        value="{{ Role::STUDENT->value }}"
+                        class="text-indigo-600 border-gray-300 focus:ring-indigo-500"
+                        @checked(old('role', Role::STUDENT->value) === Role::STUDENT->value)
+                    >
+                    <span class="ms-2 text-sm text-gray-700">{{ __('Student') }}</span>
+                </label>
+                <label class="flex items-center">
+                    <input
+                        type="radio"
+                        name="role"
+                        value="{{ Role::TEACHER->value }}"
+                        class="text-indigo-600 border-gray-300 focus:ring-indigo-500"
+                        @checked(old('role') === Role::TEACHER->value)
+                    >
+                    <span class="ms-2 text-sm text-gray-700">{{ __('Teacher') }}</span>
+                </label>
+            </div>
+            @error('role')
+                <span class="text-sm text-red-600 mt-2 block">{{ $message }}</span>
+            @enderror
+        </div>
+
+        <x-primary-button class="w-full justify-center">
+            {{ __('Complete Registration') }}
+        </x-primary-button>
+    </form>
+
+    <p class="mt-6 text-xs text-gray-500">
+        {{ __('You will be logged in automatically after completing this step.') }}
+    </p>
+</x-guest-layout>

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -26,6 +26,8 @@ Route::middleware('guest')->group(function () {
 
     Route::get('auth/{provider}/redirect', [SocialiteController::class, 'redirect'])->name('social.redirect');
     Route::get('auth/{provider}/callback', [SocialiteController::class, 'callback'])->name('social.callback');
+    Route::get('auth/{provider}/register', [SocialiteController::class, 'showRegistrationForm'])->name('social.register.show');
+    Route::post('auth/{provider}/register', [SocialiteController::class, 'completeRegistration'])->name('social.register.complete');
 
     Route::get('email-login/{user}', EmailLoginController::class)
         ->middleware('signed')

--- a/tests/Feature/Auth/SocialiteRegistrationTest.php
+++ b/tests/Feature/Auth/SocialiteRegistrationTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Enums\Role;
+use App\Models\Setting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Socialite\Contracts\Provider;
+use Laravel\Socialite\Contracts\User as SocialiteUser;
+use Laravel\Socialite\Facades\Socialite;
+use Mockery;
+use Tests\TestCase;
+
+class SocialiteRegistrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Setting::set('google_login_enabled', true);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    public function test_new_google_user_is_prompted_to_choose_role_before_registration(): void
+    {
+        $this->mockSocialiteUser('google-user@example.com', 'Google User');
+
+        $response = $this->get('/auth/google/callback');
+
+        $response->assertRedirect(route('social.register.show', ['provider' => 'google']));
+
+        $this->assertGuest();
+        $this->assertDatabaseMissing('users', ['email' => 'google-user@example.com']);
+
+        $pending = session()->get('socialite.registration');
+
+        $this->assertIsArray($pending);
+        $this->assertSame('google', $pending['provider']);
+        $this->assertSame('google-user@example.com', $pending['email']);
+        $this->assertSame('Google User', $pending['name']);
+    }
+
+    public function test_pending_social_registration_can_be_completed_with_selected_role(): void
+    {
+        $this->mockSocialiteUser('teacher@example.com', 'Teacher Example');
+
+        $this->get('/auth/google/callback')
+            ->assertRedirect(route('social.register.show', ['provider' => 'google']));
+
+        $response = $this->post('/auth/google/register', [
+            'role' => Role::TEACHER->value,
+        ]);
+
+        $response->assertRedirect(route('dashboard'));
+
+        $this->assertAuthenticated();
+
+        $user = User::where('email', 'teacher@example.com')->first();
+
+        $this->assertNotNull($user);
+        $this->assertEquals(Role::TEACHER, $user->role);
+        $this->assertNotNull($user->role_confirmed_at);
+        $this->assertNotNull($user->email_verified_at);
+        $this->assertNull(session()->get('socialite.registration'));
+    }
+
+    protected function mockSocialiteUser(string $email, string $name): void
+    {
+        $socialiteUser = Mockery::mock(SocialiteUser::class);
+        $socialiteUser->shouldReceive('getEmail')->andReturn($email);
+        $socialiteUser->shouldReceive('getName')->andReturn($name);
+        $socialiteUser->shouldReceive('getNickname')->andReturn(null);
+        $socialiteUser->shouldReceive('getAvatar')->andReturn('https://example.com/avatar.png');
+
+        $provider = Mockery::mock(Provider::class);
+        $provider->shouldReceive('user')->andReturn($socialiteUser);
+
+        Socialite::shouldReceive('driver')
+            ->with('google')
+            ->andReturn($provider);
+    }
+}


### PR DESCRIPTION
## Summary
- redirect first-time social sign-ins to a role selection screen before creating the user record
- add a dedicated view and validation to finish social registration with the chosen role
- cover the new flow with feature tests for prompting and completing registration

## Testing
- ⚠️ `php artisan test` *(fails in container because composer install cannot reach GitHub to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68ca03120924832ea77e3b0c99e7792c