### PR TITLE
Require teacher details during social registration

### DIFF
--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -118,6 +118,12 @@ class SocialiteController
 
         $validated = $request->validate([
             'role' => ['required', Rule::in([Role::TEACHER->value, Role::STUDENT->value])],
+            'institution_name' => ['required_if:role,'.Role::TEACHER->value, 'string', 'max:255'],
+            'division' => ['required_if:role,'.Role::TEACHER->value, 'string', 'max:255'],
+            'district' => ['required_if:role,'.Role::TEACHER->value, 'string', 'max:255'],
+            'thana' => ['required_if:role,'.Role::TEACHER->value, 'string', 'max:255'],
+            'phone' => ['required_if:role,'.Role::TEACHER->value, 'string', 'max:30'],
+            'address' => ['required_if:role,'.Role::TEACHER->value, 'string', 'max:1000'],
         ]);
 
         $existingUser = User::where('email', $pending['email'])->first();
@@ -131,6 +137,20 @@ class SocialiteController
 
         $role = Role::from($validated['role']);
 
+        $teacherData = [
+            'institution_name' => $validated['institution_name'] ?? null,
+            'division' => $validated['division'] ?? null,
+            'district' => $validated['district'] ?? null,
+            'thana' => $validated['thana'] ?? null,
+            'phone' => $validated['phone'] ?? null,
+            'address' => $validated['address'] ?? null,
+            'teacher_profile_completed_at' => null,
+        ];
+
+        if ($role === Role::TEACHER) {
+            $teacherData['teacher_profile_completed_at'] = now();
+        }
+
         $user = User::create([
             'name' => $pending['name'],
             'email' => $pending['email'],
@@ -139,6 +159,7 @@ class SocialiteController
             'role_confirmed_at' => now(),
             'email_verified_at' => now(),
             'avatar_url' => $pending['avatar'] ?? null,
+            ...$teacherData,
         ]);
 
         $request->session()->forget(self::REGISTRATION_SESSION_KEY);

--- a/resources/views/auth/social-register.blade.php
+++ b/resources/views/auth/social-register.blade.php
@@ -61,6 +61,88 @@ use App\Enums\Role;
             @enderror
         </div>
 
+        <div id="teacher-fields" class="space-y-4 hidden">
+            <div>
+                <label for="institution_name" class="block text-sm font-medium text-gray-700">{{ __('Institution Name') }}</label>
+                <input
+                    type="text"
+                    id="institution_name"
+                    name="institution_name"
+                    value="{{ old('institution_name') }}"
+                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                >
+                @error('institution_name')
+                    <span class="text-sm text-red-600 mt-2 block">{{ $message }}</span>
+                @enderror
+            </div>
+
+            <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div>
+                    <label for="division" class="block text-sm font-medium text-gray-700">{{ __('Division') }}</label>
+                    <input
+                        type="text"
+                        id="division"
+                        name="division"
+                        value="{{ old('division') }}"
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                    >
+                    @error('division')
+                        <span class="text-sm text-red-600 mt-2 block">{{ $message }}</span>
+                    @enderror
+                </div>
+
+                <div>
+                    <label for="district" class="block text-sm font-medium text-gray-700">{{ __('District') }}</label>
+                    <input
+                        type="text"
+                        id="district"
+                        name="district"
+                        value="{{ old('district') }}"
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                    >
+                    @error('district')
+                        <span class="text-sm text-red-600 mt-2 block">{{ $message }}</span>
+                    @enderror
+                </div>
+
+                <div>
+                    <label for="thana" class="block text-sm font-medium text-gray-700">{{ __('Upazila/Thana') }}</label>
+                    <input
+                        type="text"
+                        id="thana"
+                        name="thana"
+                        value="{{ old('thana') }}"
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                    >
+                    @error('thana')
+                        <span class="text-sm text-red-600 mt-2 block">{{ $message }}</span>
+                    @enderror
+                </div>
+
+                <div>
+                    <label for="phone" class="block text-sm font-medium text-gray-700">{{ __('Mobile Number') }}</label>
+                    <input
+                        type="text"
+                        id="phone"
+                        name="phone"
+                        value="{{ old('phone') }}"
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                    >
+                    @error('phone')
+                        <span class="text-sm text-red-600 mt-2 block">{{ $message }}</span>
+                    @enderror
+                </div>
+            </div>
+
+            <div>
+                <label for="address" class="block text-sm font-medium text-gray-700">{{ __('Address') }}</label>
+                <textarea id="address" name="address" rows="3" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">{{ old('address') }}</textarea>
+                @error('address')
+                    <span class="text-sm text-red-600 mt-2 block">{{ $message }}</span>
+                @enderror
+            </div>
+        </div>
+
         <x-primary-button class="w-full justify-center">
             {{ __('Complete Registration') }}
         </x-primary-button>
@@ -69,4 +151,31 @@ use App\Enums\Role;
     <p class="mt-6 text-xs text-gray-500">
         {{ __('You will be logged in automatically after completing this step.') }}
     </p>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const roleInputs = Array.from(document.querySelectorAll('input[name="role"]'));
+            const teacherFields = document.getElementById('teacher-fields');
+
+            if (!teacherFields || roleInputs.length === 0) {
+                return;
+            }
+
+            const toggleTeacherFields = () => {
+                const selectedRole = roleInputs.find(input => input.checked)?.value;
+
+                if (selectedRole === '{{ Role::TEACHER->value }}') {
+                    teacherFields.classList.remove('hidden');
+                } else {
+                    teacherFields.classList.add('hidden');
+                }
+            };
+
+            roleInputs.forEach(input => {
+                input.addEventListener('change', toggleTeacherFields);
+            });
+
+            toggleTeacherFields();
+        });
+    </script>
 </x-guest-layout>


### PR DESCRIPTION
## Summary
- require teacher applicants to provide division, district, thana, phone, address, and institution data before completing Google sign up
- persist the extra teacher information when creating the user and immediately mark the teacher profile as complete
- expand the social registration feature tests to cover both teacher and student flows with the new fields

## Testing
- php -l app/Http/Controllers/Auth/SocialiteController.php
- php -l tests/Feature/Auth/SocialiteRegistrationTest.php

------
https://chatgpt.com/codex/tasks/task_b_68ca0bcdde3c832ea66fd36bd8a19dad