### PR TITLE
Add migration to ensure teacher onboarding columns

### DIFF
--- a/database/migrations/2025_08_27_000002_ensure_teacher_onboarding_columns_exist.php
+++ b/database/migrations/2025_08_27_000002_ensure_teacher_onboarding_columns_exist.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('users')) {
+            return;
+        }
+
+        if (! Schema::hasColumn('users', 'role_confirmed_at')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->timestamp('role_confirmed_at')->nullable();
+            });
+        }
+
+        if (! Schema::hasColumn('users', 'avatar_url')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->string('avatar_url')->nullable();
+            });
+        }
+
+        foreach (['institution_name', 'division', 'district', 'thana', 'phone'] as $column) {
+            if (! Schema::hasColumn('users', $column)) {
+                Schema::table('users', function (Blueprint $table) use ($column) {
+                    $table->string($column)->nullable();
+                });
+            }
+        }
+
+        if (! Schema::hasColumn('users', 'address')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->text('address')->nullable();
+            });
+        }
+
+        if (! Schema::hasColumn('users', 'teacher_profile_completed_at')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->timestamp('teacher_profile_completed_at')->nullable();
+            });
+        }
+
+        if (Schema::hasColumn('users', 'role_confirmed_at')) {
+            DB::table('users')
+                ->whereNull('role_confirmed_at')
+                ->update(['role_confirmed_at' => now()]);
+        }
+    }
+
+    public function down(): void
+    {
+        // Intentionally left blank. The original migrations handle column removal.
+    }
+};


### PR DESCRIPTION
## Summary
- add a defensive migration that ensures the teacher onboarding columns exist on the users table
- backfill `role_confirmed_at` for legacy rows when the column is present

## Testing
- php -l database/migrations/2025_08_27_000002_ensure_teacher_onboarding_columns_exist.php
- php artisan test *(fails: missing vendor directory in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ca0f708560832e89231982dc35f82a