### PR TITLE
Add admin controls for user suspension, deletion, and updates

### DIFF
--- a/app/Livewire/Admin/Users/Index.php
+++ b/app/Livewire/Admin/Users/Index.php
@@ -4,6 +4,10 @@ namespace App\Livewire\Admin\Users;
 
 use App\Enums\Role;
 use App\Models\User;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+use Livewire\Attributes\On;
 use Livewire\Component;
 use Livewire\WithPagination;
 
@@ -12,6 +16,33 @@ class Index extends Component
     use WithPagination;
 
     public string $search = '';
+    public bool $showEditModal = false;
+    public bool $showSuspendModal = false;
+
+    public ?User $editingUser = null;
+    public ?User $suspendingUser = null;
+
+    /**
+     * @var array<string, mixed>
+     */
+    public array $editForm = [
+        'name' => '',
+        'email' => '',
+        'role' => '',
+        'phone' => '',
+        'address' => '',
+        'institution_name' => '',
+        'division' => '',
+        'district' => '',
+        'thana' => '',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    public array $suspendForm = [
+        'until' => '',
+    ];
 
     public function updatingSearch(): void
     {
@@ -21,8 +52,176 @@ class Index extends Component
     public function changeRole(int $userId, string $role): void
     {
         $user = User::findOrFail($userId);
-        $user->update(['role' => $role]);
+        $roleEnum = Role::tryFrom($role);
+
+        if (! $roleEnum) {
+            $this->dispatch('roleUpdated', message: 'Invalid role selected.', type: 'error');
+            return;
+        }
+
+        $user->update(['role' => $roleEnum]);
         $this->dispatch('roleUpdated', message: 'Role updated successfully.');
+    }
+
+    public function editUser(int $userId): void
+    {
+        $this->editingUser = User::findOrFail($userId);
+        $this->editForm = [
+            'name' => (string) $this->editingUser->name,
+            'email' => (string) $this->editingUser->email,
+            'role' => $this->editingUser->role?->value ?? Role::STUDENT->value,
+            'phone' => (string) ($this->editingUser->phone ?? ''),
+            'address' => (string) ($this->editingUser->address ?? ''),
+            'institution_name' => (string) ($this->editingUser->institution_name ?? ''),
+            'division' => (string) ($this->editingUser->division ?? ''),
+            'district' => (string) ($this->editingUser->district ?? ''),
+            'thana' => (string) ($this->editingUser->thana ?? ''),
+        ];
+
+        $this->resetValidation();
+        $this->showEditModal = true;
+    }
+
+    public function updateUser(): void
+    {
+        if (! $this->editingUser) {
+            return;
+        }
+
+        $data = Validator::make($this->editForm, $this->editRules())->validate();
+        $data['role'] = Role::from($data['role']);
+
+        $this->editingUser->update($data);
+
+        $this->dispatch('userUpdated', message: 'User updated successfully.');
+        $this->closeEditModal();
+    }
+
+    public function closeEditModal(): void
+    {
+        $this->showEditModal = false;
+        $this->resetValidation();
+        $this->resetEditForm();
+    }
+
+    public function openSuspendModal(int $userId): void
+    {
+        $this->suspendingUser = User::findOrFail($userId);
+        $this->suspendForm['until'] = $this->suspendingUser->suspended_until
+            ? $this->suspendingUser->suspended_until->format('Y-m-d\\TH:i')
+            : '';
+
+        $this->resetValidation();
+        $this->showSuspendModal = true;
+    }
+
+    public function saveSuspension(): void
+    {
+        if (! $this->suspendingUser) {
+            return;
+        }
+
+        $data = Validator::make($this->suspendForm, $this->suspendRules())->validate();
+
+        $until = Carbon::parse($data['until']);
+        $this->suspendingUser->update(['suspended_until' => $until]);
+
+        $this->dispatch('userSuspensionUpdated', message: 'User suspended successfully.');
+        $this->closeSuspendModal();
+    }
+
+    public function closeSuspendModal(): void
+    {
+        $this->showSuspendModal = false;
+        $this->resetValidation();
+        $this->resetSuspendForm();
+    }
+
+    public function clearSuspension(int $userId): void
+    {
+        $user = User::findOrFail($userId);
+        $user->update(['suspended_until' => null]);
+
+        if ($this->suspendingUser && $this->suspendingUser->is($user)) {
+            $this->closeSuspendModal();
+        }
+
+        $this->dispatch('userSuspensionUpdated', message: 'User suspension cleared.');
+    }
+
+    #[On('deleteUserConfirmed')]
+    public function deleteUserConfirmed(int $userId): void
+    {
+        $user = User::find($userId);
+
+        if (! $user) {
+            return;
+        }
+
+        if (auth()->id() === $userId) {
+            $this->dispatch('userDeleted', message: 'You cannot delete your own administrator account.', type: 'error');
+            return;
+        }
+
+        $user->delete();
+
+        if ($this->editingUser && $this->editingUser->is($user)) {
+            $this->closeEditModal();
+        }
+
+        if ($this->suspendingUser && $this->suspendingUser->is($user)) {
+            $this->closeSuspendModal();
+        }
+
+        $this->dispatch('userDeleted', message: 'User deleted successfully.');
+    }
+
+    protected function editRules(): array
+    {
+        $userId = $this->editingUser?->id;
+
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', Rule::unique('users', 'email')->ignore($userId)],
+            'role' => ['required', Rule::enum(Role::class)],
+            'phone' => ['nullable', 'string', 'max:50'],
+            'address' => ['nullable', 'string', 'max:255'],
+            'institution_name' => ['nullable', 'string', 'max:255'],
+            'division' => ['nullable', 'string', 'max:255'],
+            'district' => ['nullable', 'string', 'max:255'],
+            'thana' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+
+    protected function suspendRules(): array
+    {
+        return [
+            'until' => ['required', 'date', 'after:now'],
+        ];
+    }
+
+    protected function resetEditForm(): void
+    {
+        $this->editingUser = null;
+        $this->editForm = [
+            'name' => '',
+            'email' => '',
+            'role' => '',
+            'phone' => '',
+            'address' => '',
+            'institution_name' => '',
+            'division' => '',
+            'district' => '',
+            'thana' => '',
+        ];
+    }
+
+    protected function resetSuspendForm(): void
+    {
+        $this->suspendingUser = null;
+        $this->suspendForm = [
+            'until' => '',
+        ];
     }
 
     public function render()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -35,6 +35,7 @@ class User extends Authenticatable
         'address',
         'role_confirmed_at',
         'teacher_profile_completed_at',
+        'suspended_until',
     ];
 
     /**
@@ -60,6 +61,7 @@ class User extends Authenticatable
             'role' => Role::class,
             'role_confirmed_at' => 'datetime',
             'teacher_profile_completed_at' => 'datetime',
+            'suspended_until' => 'datetime',
         ];
     }
 
@@ -76,6 +78,11 @@ class User extends Authenticatable
     public function isStudent(): bool
     {
         return $this->role === Role::STUDENT;
+    }
+
+    public function isSuspended(): bool
+    {
+        return $this->suspended_until !== null && $this->suspended_until->isFuture();
     }
 
     public function isOnline(): bool

--- a/database/migrations/2025_08_27_000003_add_suspended_until_to_users_table.php
+++ b/database/migrations/2025_08_27_000003_add_suspended_until_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (! Schema::hasColumn('users', 'suspended_until')) {
+                $table->timestamp('suspended_until')->nullable()->after('teacher_profile_completed_at');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'suspended_until')) {
+                $table->dropColumn('suspended_until');
+            }
+        });
+    }
+};

--- a/resources/views/livewire/admin/users/index.blade.php
+++ b/resources/views/livewire/admin/users/index.blade.php
@@ -12,6 +12,8 @@
                 <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Name</th>
                 <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Email</th>
                 <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Role</th>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Status</th>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Actions</th>
             </tr>
             </thead>
             <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
@@ -27,10 +29,58 @@
                             @endforeach
                         </select>
                     </td>
+                    <td class="px-4 py-2">
+                        @if($user->isSuspended())
+                            <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-200">
+                                Suspended
+                            </span>
+                            <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                Until {{ $user->suspended_until?->timezone(config('app.timezone'))->format('M d, Y h:i A') }}
+                            </div>
+                        @elseif($user->suspended_until)
+                            <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-200">
+                                Suspension expired
+                            </span>
+                            <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                Ended {{ $user->suspended_until?->timezone(config('app.timezone'))->format('M d, Y h:i A') }}
+                            </div>
+                        @else
+                            <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-200">
+                                Active
+                            </span>
+                        @endif
+                    </td>
+                    <td class="px-4 py-2 space-y-2 sm:space-y-0 sm:space-x-2 sm:flex sm:items-center">
+                        <button type="button"
+                                class="inline-flex items-center px-3 py-1.5 rounded-md bg-indigo-600 text-white text-xs font-medium hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                                wire:click="editUser({{ $user->id }})">
+                            Edit
+                        </button>
+
+                        <button type="button"
+                                class="inline-flex items-center px-3 py-1.5 rounded-md bg-amber-500 text-white text-xs font-medium hover:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2"
+                                wire:click="openSuspendModal({{ $user->id }})">
+                            {{ $user->isSuspended() || $user->suspended_until ? 'Update Suspension' : 'Suspend' }}
+                        </button>
+
+                        @if($user->suspended_until)
+                            <button type="button"
+                                    class="inline-flex items-center px-3 py-1.5 rounded-md bg-green-600 text-white text-xs font-medium hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
+                                    wire:click="clearSuspension({{ $user->id }})">
+                                Lift Suspension
+                            </button>
+                        @endif
+
+                        <button type="button"
+                                onclick="confirmDelete({{ $user->id }})"
+                                class="inline-flex items-center px-3 py-1.5 rounded-md bg-red-600 text-white text-xs font-medium hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2">
+                            Delete
+                        </button>
+                    </td>
                 </tr>
             @empty
                 <tr>
-                    <td colspan="4" class="px-4 py-6 text-center text-gray-500 dark:text-gray-400">No users found.</td>
+                    <td colspan="6" class="px-4 py-6 text-center text-gray-500 dark:text-gray-400">No users found.</td>
                 </tr>
             @endforelse
             </tbody>
@@ -39,22 +89,137 @@
     <div class="mt-4">{{ $users->links() }}</div>
 </div>
 
+<x-modal name="edit-user" :show="$showEditModal" max-width="3xl" focusable>
+    <form wire:submit.prevent="updateUser" class="p-6 space-y-6">
+        <div>
+            <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">Edit user information</h2>
+            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">Update the selected user's profile information, role, and contact details.</p>
+        </div>
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+                <x-input-label for="edit-name" value="Name" />
+                <x-text-input id="edit-name" type="text" class="mt-1 block w-full" wire:model.defer="editForm.name" />
+                <x-input-error :messages="$errors->get('editForm.name')" class="mt-2" />
+            </div>
+            <div>
+                <x-input-label for="edit-email" value="Email" />
+                <x-text-input id="edit-email" type="email" class="mt-1 block w-full" wire:model.defer="editForm.email" />
+                <x-input-error :messages="$errors->get('editForm.email')" class="mt-2" />
+            </div>
+            <div>
+                <x-input-label for="edit-role" value="Role" />
+                <select id="edit-role" wire:model.defer="editForm.role" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200">
+                    <option value="">Select role</option>
+                    @foreach($roles as $roleOption)
+                        <option value="{{ $roleOption->value }}">{{ ucfirst($roleOption->value) }}</option>
+                    @endforeach
+                </select>
+                <x-input-error :messages="$errors->get('editForm.role')" class="mt-2" />
+            </div>
+            <div>
+                <x-input-label for="edit-phone" value="Phone" />
+                <x-text-input id="edit-phone" type="text" class="mt-1 block w-full" wire:model.defer="editForm.phone" />
+                <x-input-error :messages="$errors->get('editForm.phone')" class="mt-2" />
+            </div>
+            <div class="sm:col-span-2">
+                <x-input-label for="edit-address" value="Address" />
+                <x-text-input id="edit-address" type="text" class="mt-1 block w-full" wire:model.defer="editForm.address" />
+                <x-input-error :messages="$errors->get('editForm.address')" class="mt-2" />
+            </div>
+            <div>
+                <x-input-label for="edit-institution" value="Institution" />
+                <x-text-input id="edit-institution" type="text" class="mt-1 block w-full" wire:model.defer="editForm.institution_name" />
+                <x-input-error :messages="$errors->get('editForm.institution_name')" class="mt-2" />
+            </div>
+            <div>
+                <x-input-label for="edit-division" value="Division" />
+                <x-text-input id="edit-division" type="text" class="mt-1 block w-full" wire:model.defer="editForm.division" />
+                <x-input-error :messages="$errors->get('editForm.division')" class="mt-2" />
+            </div>
+            <div>
+                <x-input-label for="edit-district" value="District" />
+                <x-text-input id="edit-district" type="text" class="mt-1 block w-full" wire:model.defer="editForm.district" />
+                <x-input-error :messages="$errors->get('editForm.district')" class="mt-2" />
+            </div>
+            <div>
+                <x-input-label for="edit-thana" value="Thana" />
+                <x-text-input id="edit-thana" type="text" class="mt-1 block w-full" wire:model.defer="editForm.thana" />
+                <x-input-error :messages="$errors->get('editForm.thana')" class="mt-2" />
+            </div>
+        </div>
+
+        <div class="flex justify-end space-x-3">
+            <x-secondary-button type="button" wire:click="closeEditModal">Cancel</x-secondary-button>
+            <x-primary-button>Save changes</x-primary-button>
+        </div>
+    </form>
+</x-modal>
+
+<x-modal name="suspend-user" :show="$showSuspendModal" focusable>
+    <form wire:submit.prevent="saveSuspension" class="p-6 space-y-6">
+        <div>
+            <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">Schedule a suspension</h2>
+            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">Choose when the user's account should remain suspended. The user will regain access automatically after the selected time.</p>
+        </div>
+
+        <div>
+            <x-input-label for="suspend-until" value="Suspend until" />
+            <x-text-input id="suspend-until" type="datetime-local" class="mt-1 block w-full" wire:model.defer="suspendForm.until" />
+            <x-input-error :messages="$errors->get('suspendForm.until')" class="mt-2" />
+        </div>
+
+        <div class="flex justify-end space-x-3">
+            <x-secondary-button type="button" wire:click="closeSuspendModal">Cancel</x-secondary-button>
+            <x-primary-button>Save suspension</x-primary-button>
+        </div>
+    </form>
+</x-modal>
+
 @push('scripts')
 <script>
-    function showToast(message) {
-        if (!window.Swal) return;
+    function showToast(message, type = 'success') {
+        if (!window.Swal || !message) return;
         Swal.fire({
             toast: true,
-            icon: 'success',
+            icon: type,
             title: message,
             position: 'top-end',
             showConfirmButton: false,
-            timer: 1500,
+            timer: 2000,
+        });
+    }
+
+    function confirmDelete(id) {
+        if (!window.Swal) return;
+        Swal.fire({
+            title: 'Delete this user?',
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonColor: '#d33',
+            cancelButtonColor: '#3085d6',
+            confirmButtonText: 'Yes, delete it!'
+        }).then((result) => {
+            if (result.isConfirmed) {
+                Livewire.dispatch('deleteUserConfirmed', { id: id });
+            }
         });
     }
 
     window.addEventListener('roleUpdated', e => {
-        showToast(e.detail.message || 'Role updated successfully.');
+        showToast(e.detail.message || 'Role updated successfully.', e.detail.type || 'success');
+    });
+
+    window.addEventListener('userUpdated', e => {
+        showToast(e.detail.message || 'User updated successfully.', e.detail.type || 'success');
+    });
+
+    window.addEventListener('userSuspensionUpdated', e => {
+        showToast(e.detail.message || 'User suspension updated.', e.detail.type || 'success');
+    });
+
+    window.addEventListener('userDeleted', e => {
+        showToast(e.detail.message || 'User deleted successfully.', e.detail.type || 'success');
     });
 </script>
 @endpush


### PR DESCRIPTION
## Summary
- add a suspended_until timestamp to users with model casting and helpers
- enhance the admin users Livewire component with edit, suspension, and deletion workflows
- refresh the admin users blade view to expose new modals, status chips, and toast messaging

## Testing
- php artisan test *(fails: vendor/autoload.php missing because composer install requires a GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb26e418f483269602bfa7ba8ef30d