### PR TITLE
Handle extended modal max width options

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -5,13 +5,20 @@
 ])
 
 @php
-$maxWidth = [
+$maxWidths = [
     'sm' => 'sm:max-w-sm',
     'md' => 'sm:max-w-md',
     'lg' => 'sm:max-w-lg',
     'xl' => 'sm:max-w-xl',
     '2xl' => 'sm:max-w-2xl',
-][$maxWidth];
+    '3xl' => 'sm:max-w-3xl',
+    '4xl' => 'sm:max-w-4xl',
+    '5xl' => 'sm:max-w-5xl',
+    '6xl' => 'sm:max-w-6xl',
+    '7xl' => 'sm:max-w-7xl',
+];
+
+$maxWidth = $maxWidths[$maxWidth] ?? $maxWidths['2xl'];
 @endphp
 
 <div


### PR DESCRIPTION
## Summary
- expand the modal component's max-width map to include Tailwind's 3xl–7xl sizes
- fall back to a safe default when an unsupported max width is requested to avoid undefined key notices

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2a2ab2bc8326a24b67b5eb2f70b6