### PR TITLE
Fix delete user confirmation event payload

### DIFF
--- a/resources/views/livewire/admin/users/index.blade.php
+++ b/resources/views/livewire/admin/users/index.blade.php
@@ -203,7 +203,7 @@
             confirmButtonText: 'Yes, delete it!'
         }).then((result) => {
             if (result.isConfirmed) {
-                Livewire.dispatch('deleteUserConfirmed', { id: id });
+                Livewire.dispatch('deleteUserConfirmed', { userId: id });
             }
         });
     }


### PR DESCRIPTION
## Summary
- send the delete confirmation event with a userId field that matches the Livewire listener parameter

## Testing
- composer install *(fails: requires GitHub token in this environment)*
- php artisan test *(blocked by missing vendor autoloader)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2f15a5f48326b5b3051cccf7afbc