### PR TITLE
Fix admin user modal handling and add regression test

### DIFF
--- a/app/Livewire/Admin/Users/Index.php
+++ b/app/Livewire/Admin/Users/Index.php
@@ -80,6 +80,7 @@ class Index extends Component
 
         $this->resetValidation();
         $this->showEditModal = true;
+        $this->dispatch('open-modal', 'edit-user');
     }
 
     public function updateUser(): void
@@ -100,6 +101,7 @@ class Index extends Component
     public function closeEditModal(): void
     {
         $this->showEditModal = false;
+        $this->dispatch('close-modal', 'edit-user');
         $this->resetValidation();
         $this->resetEditForm();
     }
@@ -113,6 +115,7 @@ class Index extends Component
 
         $this->resetValidation();
         $this->showSuspendModal = true;
+        $this->dispatch('open-modal', 'suspend-user');
     }
 
     public function saveSuspension(): void
@@ -133,6 +136,7 @@ class Index extends Component
     public function closeSuspendModal(): void
     {
         $this->showSuspendModal = false;
+        $this->dispatch('close-modal', 'suspend-user');
         $this->resetValidation();
         $this->resetSuspendForm();
     }

--- a/tests/Feature/Admin/ManageUsersTest.php
+++ b/tests/Feature/Admin/ManageUsersTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\Role;
+use App\Livewire\Admin\Users\Index;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ManageUsersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_open_edit_modal_and_update_user(): void
+    {
+        $admin = User::factory()->create(['role' => Role::ADMIN]);
+        $user = User::factory()->create([
+            'role' => Role::STUDENT,
+            'name' => 'Original Name',
+            'email' => 'original@example.com',
+            'phone' => '0123456789',
+            'address' => 'Old Address',
+            'institution_name' => 'Old Institution',
+            'division' => 'Old Division',
+            'district' => 'Old District',
+            'thana' => 'Old Thana',
+        ]);
+
+        $this->actingAs($admin);
+
+        Livewire::test(Index::class)
+            ->call('editUser', $user->id)
+            ->assertSet('showEditModal', true)
+            ->assertDispatched('open-modal', fn ($payload) => $payload === 'edit-user')
+            ->set('editForm.name', 'Updated Name')
+            ->set('editForm.email', 'updated@example.com')
+            ->set('editForm.role', Role::TEACHER->value)
+            ->set('editForm.phone', '0987654321')
+            ->set('editForm.address', 'New Address')
+            ->set('editForm.institution_name', 'New Institution')
+            ->set('editForm.division', 'New Division')
+            ->set('editForm.district', 'New District')
+            ->set('editForm.thana', 'New Thana')
+            ->call('updateUser')
+            ->assertDispatched('userUpdated')
+            ->assertSet('showEditModal', false)
+            ->assertDispatched('close-modal', fn ($payload) => $payload === 'edit-user');
+
+        $user->refresh();
+
+        $this->assertSame('Updated Name', $user->name);
+        $this->assertSame('updated@example.com', $user->email);
+        $this->assertEquals(Role::TEACHER, $user->role);
+        $this->assertSame('0987654321', $user->phone);
+        $this->assertSame('New Address', $user->address);
+        $this->assertSame('New Institution', $user->institution_name);
+        $this->assertSame('New Division', $user->division);
+        $this->assertSame('New District', $user->district);
+        $this->assertSame('New Thana', $user->thana);
+    }
+}


### PR DESCRIPTION
## Summary
- dispatch the Jetstream `open-modal`/`close-modal` events when showing or hiding the admin user edit and suspension dialogs
- add a regression test covering admin user editing, including modal visibility events and persisted updates

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing because composer install cannot reach GitHub in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb309a5ad48326a9c0ca386aef68d5