### PR TITLE
Add sub-subject selection for student exams

### DIFF
--- a/resources/views/livewire/student/exam.blade.php
+++ b/resources/views/livewire/student/exam.blade.php
@@ -8,6 +8,13 @@
                 @endforeach
             </select>
 
+            <select wire:model="subSubjectId" class="w-full border rounded px-3 py-2">
+                <option value="">সাব-বিষয় সিলেক্ট করো</option>
+                @foreach($subSubjects as $subSubject)
+                    <option value="{{ $subSubject->id }}">{{ $subSubject->name }}</option>
+                @endforeach
+            </select>
+
             <select wire:model="chapterId" class="w-full border rounded px-3 py-2">
                 <option value="">অধ্যায় সিলেক্ট করো</option>
                 @foreach($chapters as $chapter)


### PR DESCRIPTION
## Summary
- extend the student exam Livewire component to load sub-subjects and filter chapters based on the chosen subject and sub-subject
- update the exam setup view to include a sub-subject dropdown while keeping the ability to choose all chapters

## Testing
- ⚠️ `php artisan test` *(fails: composer install requires a GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cc1a67b4b4832e840d9fbff2db65de