### PR TITLE
Add question type controls and marks to questions

### DIFF
--- a/app/Models/Question.php
+++ b/app/Models/Question.php
@@ -14,11 +14,21 @@ class Question extends Model
     use SoftDeletes;
 
     protected $fillable = [
-        'subject_id', 'sub_subject_id', 'chapter_id', 'title', 'difficulty', 'slug', 'views', 'user_id',
+        'subject_id',
+        'sub_subject_id',
+        'chapter_id',
+        'title',
+        'difficulty',
+        'question_type',
+        'marks',
+        'slug',
+        'views',
+        'user_id',
     ];
 
     protected $casts = [
         'views' => 'integer',
+        'marks' => 'float',
     ];
 
     protected static function boot()

--- a/database/migrations/2025_09_20_000000_add_marks_to_questions_table.php
+++ b/database/migrations/2025_09_20_000000_add_marks_to_questions_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\\Database\\Migrations\\Migration;
+use Illuminate\\Database\\Schema\\Blueprint;
+use Illuminate\\Support\\Facades\\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('questions', function (Blueprint $table) {
+            $table->decimal('marks', 8, 2)->default(0)->after('question_type');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('questions', function (Blueprint $table) {
+            $table->dropColumn('marks');
+        });
+    }
+};

--- a/resources/views/livewire/admin/questions.blade.php
+++ b/resources/views/livewire/admin/questions.blade.php
@@ -33,6 +33,8 @@
                 <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Created By</th>
                 <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Subject</th>
                 <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Chapter</th>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Type</th>
+                <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Marks</th>
                 <th class="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Actions</th>
             </tr>
             </thead>
@@ -44,6 +46,8 @@
                     <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $q->user->name }}</td>
                     <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $q->subject->name }}</td>
                     <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $q->chapter?->name }}</td>
+                    <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ strtoupper($q->question_type ?? 'MCQ') }}</td>
+                    <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $q->marks }}</td>
                     <td class="px-4 py-2 space-x-2">
                         <a wire:navigate href="{{ route(auth()->user()->isAdmin() ? 'admin.questions.edit' : 'teacher.questions.edit', $q) }}"
                            class="text-indigo-600 hover:text-indigo-800 dark:text-indigo-400 dark:hover:text-indigo-300">Edit</a>
@@ -54,7 +58,7 @@
                 </tr>
             @empty
                 <tr>
-                    <td colspan="5" class="px-4 py-6 text-center text-gray-500 dark:text-gray-400">No questions found.</td>
+                    <td colspan="8" class="px-4 py-6 text-center text-gray-500 dark:text-gray-400">No questions found.</td>
                 </tr>
             @endforelse
             </tbody>

--- a/resources/views/livewire/admin/questions/create.blade.php
+++ b/resources/views/livewire/admin/questions/create.blade.php
@@ -1,7 +1,7 @@
-<div x-data class="max-w-4xl mx-auto p-6 bg-white dark:bg-gray-800 rounded-lg shadow">
+<div x-data="{ questionType: @entangle('question_type') }" class="max-w-4xl mx-auto p-6 bg-white dark:bg-gray-800 rounded-lg shadow">
     <form wire:submit.prevent="save" class="space-y-6">
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-            {{-- Subject --}}
+            {{-- Subject --}} 
             <div wire:ignore wire:key="create-subject-select">
                 <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Subject</label>
                 <select id="subject" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
@@ -35,21 +35,42 @@
             </div>
         </div>
 
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {{-- Difficulty --}}
+            <div>
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Difficulty</label>
+                <select wire:model="difficulty" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
+                    <option value="easy">Easy</option>
+                    <option value="medium">Medium</option>
+                    <option value="hard">Hard</option>
+                </select>
+                @error('difficulty')<span class="text-sm text-red-600 dark:text-red-400">{{ $message }}</span>@enderror
+            </div>
+
+            {{-- Question Type --}}
+            <div>
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Question Type</label>
+                <select wire:model="question_type" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
+                    <option value="mcq">MCQ</option>
+                    <option value="cq">CQ</option>
+                    <option value="short">Short</option>
+                </select>
+                @error('question_type')<span class="text-sm text-red-600 dark:text-red-400">{{ $message }}</span>@enderror
+            </div>
+
+            {{-- Marks --}}
+            <div>
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Marks</label>
+                <input type="number" step="0.5" min="0" wire:model="marks" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500" />
+                @error('marks')<span class="text-sm text-red-600 dark:text-red-400">{{ $message }}</span>@enderror
+            </div>
+        </div>
+
         {{-- Main Question --}}
         <div wire:ignore>
             <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Question</label>
             <div id="editor" class="border border-gray-300 dark:border-gray-600 min-h-32 p-2 dark:bg-gray-700 dark:text-gray-100"></div>
             @error('title')<span class="text-sm text-red-600 dark:text-red-400">{{ $message }}</span>@enderror
-        </div>
-
-        {{-- Difficulty --}}
-        <div>
-            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Difficulty</label>
-            <select wire:model="difficulty" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
-                <option value="easy">Easy</option>
-                <option value="medium">Medium</option>
-                <option value="hard">Hard</option>
-            </select>
         </div>
 
         {{-- Tags --}}
@@ -63,7 +84,7 @@
         </div>
 
         {{-- Options --}}
-        <div class="space-y-4">
+        <div class="space-y-4" x-show="questionType === 'mcq'">
             <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Options</label>
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 @foreach($options as $i => $opt)
@@ -78,6 +99,8 @@
                     </div>
                 @endforeach
             </div>
+            @error('options')<span class="text-sm text-red-600 dark:text-red-400">{{ $message }}</span>@enderror
+            @error('options.*.option_text')<span class="text-sm text-red-600 dark:text-red-400">{{ $message }}</span>@enderror
         </div>
 
         <button type="submit" class="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-md focus:outline-none focus:ring-2 focus:ring-green-500">
@@ -245,5 +268,6 @@
 
         document.addEventListener('livewire:load', initEditors);
         document.addEventListener('livewire:navigated', initEditors);
+        document.addEventListener('livewire:update', initEditors);
     </script>
 @endpush

--- a/resources/views/livewire/admin/questions/edit.blade.php
+++ b/resources/views/livewire/admin/questions/edit.blade.php
@@ -1,4 +1,4 @@
-<div x-data class="max-w-4xl mx-auto p-6 bg-white dark:bg-gray-800 rounded-lg shadow">
+<div x-data="{ questionType: @entangle('question_type') }" class="max-w-4xl mx-auto p-6 bg-white dark:bg-gray-800 rounded-lg shadow">
     <form wire:submit.prevent="save" class="space-y-6">
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
             {{-- Subject --}}
@@ -35,20 +35,41 @@
             </div>
         </div>
 
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {{-- Difficulty --}}
+            <div>
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Difficulty</label>
+                <select wire:model="difficulty" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
+                    <option value="easy">Easy</option>
+                    <option value="medium">Medium</option>
+                    <option value="hard">Hard</option>
+                </select>
+                @error('difficulty')<span class="text-sm text-red-600 dark:text-red-400">{{ $message }}</span>@enderror
+            </div>
+
+            {{-- Question Type --}}
+            <div>
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Question Type</label>
+                <select wire:model="question_type" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
+                    <option value="mcq">MCQ</option>
+                    <option value="cq">CQ</option>
+                    <option value="short">Short</option>
+                </select>
+                @error('question_type')<span class="text-sm text-red-600 dark:text-red-400">{{ $message }}</span>@enderror
+            </div>
+
+            {{-- Marks --}}
+            <div>
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Marks</label>
+                <input type="number" step="0.5" min="0" wire:model="marks" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500" />
+                @error('marks')<span class="text-sm text-red-600 dark:text-red-400">{{ $message }}</span>@enderror
+            </div>
+        </div>
+
         {{-- Main Question --}}
         <div wire:ignore>
             <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Question</label>
             <div id="editor" class="border border-gray-300 dark:border-gray-600 min-h-32 p-2 dark:bg-gray-700 dark:text-gray-100">{!! $title !!}</div>
-        </div>
-
-        {{-- Difficulty --}}
-        <div>
-            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Difficulty</label>
-            <select wire:model="difficulty" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500">
-                <option value="easy">Easy</option>
-                <option value="medium">Medium</option>
-                <option value="hard">Hard</option>
-            </select>
         </div>
 
         {{-- Tags --}}
@@ -62,7 +83,7 @@
         </div>
 
         {{-- Options --}}
-        <div class="space-y-4">
+        <div class="space-y-4" x-show="questionType === 'mcq'">
             <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Options</label>
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 @foreach($options as $i => $opt)
@@ -77,6 +98,8 @@
                     </div>
                 @endforeach
             </div>
+            @error('options')<span class="text-sm text-red-600 dark:text-red-400">{{ $message }}</span>@enderror
+            @error('options.*.option_text')<span class="text-sm text-red-600 dark:text-red-400">{{ $message }}</span>@enderror
         </div>
 
         <button type="submit" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
@@ -244,5 +267,6 @@
 
         document.addEventListener('livewire:load', initEditors);
         document.addEventListener('livewire:navigated', initEditors);
+        document.addEventListener('livewire:update', initEditors);
     </script>
 @endpush

--- a/resources/views/livewire/admin/questions/question-form.blade.php
+++ b/resources/views/livewire/admin/questions/question-form.blade.php
@@ -1,4 +1,4 @@
-<div x-data>
+<div x-data="{ questionType: @entangle('question_type') }">
     <form wire:submit.prevent="save" class="space-y-4">
         {{-- Subject --}}
         <div>
@@ -33,20 +33,41 @@
             </select>
         </div>
 
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {{-- Difficulty --}}
+            <div>
+                <label>Difficulty</label>
+                <select wire:model="difficulty" class="border p-2 rounded w-full">
+                    <option value="easy">Easy</option>
+                    <option value="medium">Medium</option>
+                    <option value="hard">Hard</option>
+                </select>
+                @error('difficulty')<span class="text-sm text-red-600">{{ $message }}</span>@enderror
+            </div>
+
+            {{-- Question Type --}}
+            <div>
+                <label>Question Type</label>
+                <select wire:model="question_type" class="border p-2 rounded w-full">
+                    <option value="mcq">MCQ</option>
+                    <option value="cq">CQ</option>
+                    <option value="short">Short</option>
+                </select>
+                @error('question_type')<span class="text-sm text-red-600">{{ $message }}</span>@enderror
+            </div>
+
+            {{-- Marks --}}
+            <div>
+                <label>Marks</label>
+                <input type="number" step="0.5" min="0" wire:model="marks" class="border p-2 rounded w-full" />
+                @error('marks')<span class="text-sm text-red-600">{{ $message }}</span>@enderror
+            </div>
+        </div>
+
         {{-- Main Question --}}
         <div wire:ignore>
             <label>Question</label>
             <div id="editor" class="border min-h-32 p-2 rounded"></div>
-        </div>
-
-        {{-- Difficulty --}}
-        <div>
-            <label>Difficulty</label>
-            <select wire:model="difficulty" class="border p-2 rounded">
-                <option value="easy">Easy</option>
-                <option value="medium">Medium</option>
-                <option value="hard">Hard</option>
-            </select>
         </div>
 
         {{-- Tags --}}
@@ -60,7 +81,7 @@
         </div>
 
         {{-- Options --}}
-        <div class="space-y-2">
+        <div class="space-y-2" x-show="questionType === 'mcq'">
             <label>Options</label>
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 @foreach($options as $i => $opt)
@@ -74,6 +95,8 @@
                     </div>
                 @endforeach
             </div>
+            @error('options')<span class="text-sm text-red-600">{{ $message }}</span>@enderror
+            @error('options.*.option_text')<span class="text-sm text-red-600">{{ $message }}</span>@enderror
         </div>
 
         <button type="submit" class="bg-green-500 text-white px-4 py-2 rounded">
@@ -143,5 +166,6 @@
             document.addEventListener('DOMContentLoaded', initEditors);
         }
         document.addEventListener('livewire:navigated', initEditors);
+        document.addEventListener('livewire:update', initEditors);
     </script>
 @endpush


### PR DESCRIPTION
## Summary
- add a migration to store per-question marks alongside the existing question type column
- extend the question model, Livewire create/edit logic, and shared form component to capture question type and marks while skipping options for non-MCQ questions
- refresh the question creation and edit blades to expose the new fields, hide the options grid unless MCQ is selected, and surface type/marks in the questions table

## Testing
- `php artisan test` *(fails: vendor dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd5c00cb688326bd6df02211dcba40