### PR TITLE
Add optional question description and improve validation feedback

### DIFF
--- a/app/Livewire/Admin/Questions/Create.php
+++ b/app/Livewire/Admin/Questions/Create.php
@@ -10,7 +10,7 @@ class Create extends Component
 {
     use AuthorizesRequests;
 
-    public $subject_id, $sub_subject_id, $chapter_id, $title, $difficulty = 'easy', $question_type = 'mcq', $marks = 1, $tagIds = [];
+    public $subject_id, $sub_subject_id, $chapter_id, $title, $description, $difficulty = 'easy', $question_type = 'mcq', $marks = 1, $tagIds = [];
     public $options = [
         ['option_text' => '', 'is_correct' => false],
         ['option_text' => '', 'is_correct' => false],
@@ -25,7 +25,7 @@ class Create extends Component
 
     public function resetFields(): void
     {
-        $this->reset('subject_id', 'sub_subject_id', 'chapter_id', 'title', 'difficulty', 'question_type', 'marks', 'tagIds', 'options');
+        $this->reset('subject_id', 'sub_subject_id', 'chapter_id', 'title', 'description', 'difficulty', 'question_type', 'marks', 'tagIds', 'options');
         $this->difficulty = 'easy';
         $this->question_type = 'mcq';
         $this->marks = 1;
@@ -90,6 +90,7 @@ class Create extends Component
             'sub_subject_id' => 'nullable|exists:sub_subjects,id',
             'chapter_id' => 'required_with:sub_subject_id|nullable|exists:chapters,id',
             'title' => 'required|string',
+            'description' => 'nullable|string',
             'difficulty' => 'required|in:easy,medium,hard',
             'question_type' => 'required|in:mcq,cq,short',
             'marks' => 'required|numeric|min:0',
@@ -108,6 +109,7 @@ class Create extends Component
             'sub_subject_id' => $this->sub_subject_id ?: null,
             'chapter_id' => $this->chapter_id ?: null,
             'title' => $this->title,
+            'description' => $this->description,
             'difficulty' => $this->difficulty,
             'question_type' => $this->question_type,
             'marks' => $this->marks,

--- a/app/Livewire/Admin/Questions/Edit.php
+++ b/app/Livewire/Admin/Questions/Edit.php
@@ -11,7 +11,7 @@ class Edit extends Component
     use AuthorizesRequests;
 
     public Question $question;
-    public $subject_id, $sub_subject_id, $chapter_id, $title, $difficulty, $question_type = 'mcq', $marks = 1, $tagIds = [], $options = [];
+    public $subject_id, $sub_subject_id, $chapter_id, $title, $description, $difficulty, $question_type = 'mcq', $marks = 1, $tagIds = [], $options = [];
 
     public function mount(Question $question)
     {
@@ -24,6 +24,7 @@ class Edit extends Component
         $this->sub_subject_id = $question->sub_subject_id;
         $this->chapter_id = $question->chapter_id;
         $this->title = $question->title;
+        $this->description = $question->description;
         $this->difficulty = $question->difficulty;
         $this->question_type = $question->question_type ?? 'mcq';
         $this->marks = $question->marks ?? 1;
@@ -33,7 +34,7 @@ class Edit extends Component
 
     public function resetFields(): void
     {
-        $this->reset('subject_id', 'sub_subject_id', 'chapter_id', 'title', 'difficulty', 'question_type', 'marks', 'tagIds', 'options');
+        $this->reset('subject_id', 'sub_subject_id', 'chapter_id', 'title', 'description', 'difficulty', 'question_type', 'marks', 'tagIds', 'options');
         $this->dispatch('reset-selects');
     }
 
@@ -62,6 +63,7 @@ class Edit extends Component
             'sub_subject_id' => 'nullable|exists:sub_subjects,id',
             'chapter_id' => 'required_with:sub_subject_id|nullable|exists:chapters,id',
             'title' => 'required|string',
+            'description' => 'nullable|string',
             'difficulty' => 'required|in:easy,medium,hard',
             'question_type' => 'required|in:mcq,cq,short',
             'marks' => 'required|numeric|min:0',
@@ -80,6 +82,7 @@ class Edit extends Component
             'sub_subject_id' => $this->sub_subject_id ?: null,
             'chapter_id' => $this->chapter_id ?: null,
             'title' => $this->title,
+            'description' => $this->description,
             'difficulty' => $this->difficulty,
             'question_type' => $this->question_type,
             'marks' => $this->marks,

--- a/app/Models/Question.php
+++ b/app/Models/Question.php
@@ -18,6 +18,7 @@ class Question extends Model
         'sub_subject_id',
         'chapter_id',
         'title',
+        'description',
         'difficulty',
         'question_type',
         'marks',

--- a/database/migrations/2025_10_11_000000_add_description_to_questions_table.php
+++ b/database/migrations/2025_10_11_000000_add_description_to_questions_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('questions', function (Blueprint $table) {
+            $table->longText('description')->nullable()->after('title');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('questions', function (Blueprint $table) {
+            $table->dropColumn('description');
+        });
+    }
+};

--- a/resources/views/livewire/admin/questions/create.blade.php
+++ b/resources/views/livewire/admin/questions/create.blade.php
@@ -10,6 +10,7 @@
                         <option value="{{ $s->id }}" @selected($s->id == $subject_id)>{{ $s->name }}</option>
                     @endforeach
                 </select>
+                @error('subject_id')<span class="text-sm text-red-600 dark:text-red-400">{{ $message }}</span>@enderror
             </div>
 
             {{-- Sub-Subject (Optional) --}}
@@ -21,6 +22,7 @@
                         <option value="{{ $ss->id }}" @selected($ss->id == $sub_subject_id)>{{ $ss->name }}</option>
                     @endforeach
                 </select>
+                @error('sub_subject_id')<span class="text-sm text-red-600 dark:text-red-400">{{ $message }}</span>@enderror
             </div>
 
             {{-- Chapter (Required if Sub-Subject) --}}
@@ -32,6 +34,7 @@
                         <option value="{{ $c->id }}" @selected($c->id == $chapter_id)>{{ $c->name }}</option>
                     @endforeach
                 </select>
+                @error('chapter_id')<span class="text-sm text-red-600 dark:text-red-400">{{ $message }}</span>@enderror
             </div>
         </div>
 
@@ -64,6 +67,13 @@
                 <input type="number" step="0.5" min="0" wire:model="marks" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500" />
                 @error('marks')<span class="text-sm text-red-600 dark:text-red-400">{{ $message }}</span>@enderror
             </div>
+        </div>
+
+        {{-- Question Description (Optional) --}}
+        <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Description (Optional)</label>
+            <textarea wire:model.defer="description" rows="3" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500"></textarea>
+            @error('description')<span class="text-sm text-red-600 dark:text-red-400">{{ $message }}</span>@enderror
         </div>
 
         {{-- Main Question --}}

--- a/resources/views/livewire/admin/questions/edit.blade.php
+++ b/resources/views/livewire/admin/questions/edit.blade.php
@@ -10,6 +10,7 @@
                         <option value="{{ $s->id }}" @selected($s->id == $subject_id)>{{ $s->name }}</option>
                     @endforeach
                 </select>
+                @error('subject_id')<span class="text-sm text-red-600 dark:text-red-400">{{ $message }}</span>@enderror
             </div>
 
             {{-- Sub-Subject (Optional) --}}
@@ -21,6 +22,7 @@
                         <option value="{{ $ss->id }}" @selected($ss->id == $sub_subject_id)>{{ $ss->name }}</option>
                     @endforeach
                 </select>
+                @error('sub_subject_id')<span class="text-sm text-red-600 dark:text-red-400">{{ $message }}</span>@enderror
             </div>
 
             {{-- Chapter (Required if Sub-Subject) --}}
@@ -32,6 +34,7 @@
                         <option value="{{ $c->id }}" @selected($c->id == $chapter_id)>{{ $c->name }}</option>
                     @endforeach
                 </select>
+                @error('chapter_id')<span class="text-sm text-red-600 dark:text-red-400">{{ $message }}</span>@enderror
             </div>
         </div>
 
@@ -66,10 +69,18 @@
             </div>
         </div>
 
+        {{-- Question Description (Optional) --}}
+        <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Description (Optional)</label>
+            <textarea wire:model.defer="description" rows="3" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:ring-indigo-500 focus:border-indigo-500"></textarea>
+            @error('description')<span class="text-sm text-red-600 dark:text-red-400">{{ $message }}</span>@enderror
+        </div>
+
         {{-- Main Question --}}
         <div wire:ignore>
             <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Question</label>
             <div id="editor" class="border border-gray-300 dark:border-gray-600 min-h-32 p-2 dark:bg-gray-700 dark:text-gray-100">{!! $title !!}</div>
+            @error('title')<span class="text-sm text-red-600 dark:text-red-400">{{ $message }}</span>@enderror
         </div>
 
         {{-- Tags --}}


### PR DESCRIPTION
## Summary
- allow admins to capture an optional description when creating or editing questions
- persist the new description field on the Question model and database table
- surface validation feedback for subject, sub-subject, chapter, question, and description inputs in the create/edit forms

## Testing
- not run (composer install requires a GitHub token in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68cd6c501e80832682207f003751f3d8