### PR TITLE
Prevent suspended users from logging in

### DIFF
--- a/app/Livewire/Admin/Users/Index.php
+++ b/app/Livewire/Admin/Users/Index.php
@@ -108,6 +108,12 @@ class Index extends Component
 
     public function openSuspendModal(int $userId): void
     {
+        if (auth()->id() === $userId) {
+            $this->dispatch('userSuspensionUpdated', message: 'You cannot suspend your own account.', type: 'error');
+
+            return;
+        }
+
         $this->suspendingUser = User::findOrFail($userId);
         $this->suspendForm['until'] = $this->suspendingUser->suspended_until
             ? $this->suspendingUser->suspended_until->format('Y-m-d\\TH:i')
@@ -121,6 +127,12 @@ class Index extends Component
     public function saveSuspension(): void
     {
         if (! $this->suspendingUser) {
+            return;
+        }
+
+        if ($this->suspendingUser->is(auth()->user())) {
+            $this->dispatch('userSuspensionUpdated', message: 'You cannot suspend your own account.', type: 'error');
+
             return;
         }
 

--- a/app/Notifications/SuspendedLoginAttempt.php
+++ b/app/Notifications/SuspendedLoginAttempt.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Carbon;
+
+class SuspendedLoginAttempt extends Notification
+{
+    use Queueable;
+
+    public function __construct(protected Carbon $suspendedUntil)
+    {
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $timezone = config('app.timezone');
+        $until = $this->suspendedUntil->copy()->timezone($timezone);
+        $duration = now()->diffForHumans($this->suspendedUntil, true);
+
+        return (new MailMessage)
+            ->subject(__('Your account is currently suspended'))
+            ->line(__('You attempted to log in while your account is suspended.'))
+            ->line(__('You will regain access on :date.', [
+                'date' => $until->toDayDateTimeString(),
+            ]))
+            ->line(__('That is approximately :duration from now.', [
+                'duration' => $duration,
+            ]));
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        $timezone = config('app.timezone');
+
+        return [
+            'suspended_until' => $this->suspendedUntil->copy()->timezone($timezone)->toIso8601String(),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- block suspended accounts from signing in through the manual login form and send an email notice with the remaining suspension time
- prevent suspended accounts from authenticating through Google or Facebook and show the suspension message
- stop administrators from suspending their own account and reuse the suspension notice

## Testing
- `php artisan test` *(fails: missing vendor directory; composer install requires GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7277948c8326929867eb3ef5acfe