### PR TITLE
Fix admin and panel header alignment with sidebar

### DIFF
--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -22,8 +22,8 @@
     <div class="min-h-screen bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200 antialiased">
         <livewire:admin.partials.sidebar />
         {{-- Main Content --}}
-        <livewire:admin.partials.header />
         <div id="mainContent" class="flex-1 md:ml-64 print:p-0 print:space-y-0 p-4 md:p-8 space-y-6 transition-all duration-200">
+            <livewire:admin.partials.header />
             {{ $slot }}
         </div>
 

--- a/resources/views/layouts/panel.blade.php
+++ b/resources/views/layouts/panel.blade.php
@@ -23,8 +23,8 @@
 <div class="min-h-screen bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200 antialiased">
     <livewire:admin.partials.sidebar />
     {{-- Topbar/Header --}}
-    <livewire:admin.partials.header />
     <div id="mainContent" class="flex-1 md:ml-64 print:p-0 print:space-y-0 p-4 md:p-8 space-y-6 transition-all duration-200">
+        <livewire:admin.partials.header />
         {{ $slot }}
     </div>
 </div>


### PR DESCRIPTION
## Summary
- move the admin header component inside the main content container so it inherits the sidebar offset
- apply the same layout adjustment to the shared panel layout to keep the top bar clear of the sidebar

## Testing
- php artisan test *(fails: vendor autoloader missing and composer install requires a GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9584c3d48326912b0921e1e7eada