### PR TITLE
Mark student email registrations as confirmed

### DIFF
--- a/resources/views/livewire/pages/auth/register.blade.php
+++ b/resources/views/livewire/pages/auth/register.blade.php
@@ -45,7 +45,7 @@ new #[Layout('layouts.guest')] class extends Component
 
         $validated['password'] = Hash::make($validated['password']);
         $validated['role'] = Role::STUDENT;
-        $validated['role_confirmed_at'] = null;
+        $validated['role_confirmed_at'] = now();
 
         event(new Registered($user = User::create($validated)));
 

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -38,7 +38,7 @@ class RegistrationTest extends TestCase
         $user = User::where('email', 'test@example.com')->first();
 
         $this->assertNotNull($user);
-        $this->assertNull($user->role_confirmed_at);
+        $this->assertNotNull($user->role_confirmed_at);
         $this->assertEquals(Role::STUDENT, $user->role);
     }
 


### PR DESCRIPTION
## Summary
- mark new email registrations as confirmed student accounts so they skip the teacher onboarding prompt
- update the registration feature test to expect an immediate confirmation timestamp

## Testing
- Unable to run `php artisan test` (missing Composer dependencies in container environment)


------
https://chatgpt.com/codex/tasks/task_e_68d2ad2ba4f88326868a0e35f1169e4e