### PR TITLE
Allow student social registrations without teacher fields

### DIFF
--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -147,18 +147,18 @@ class SocialiteController
 
         $role = Role::from($validated['role']);
 
-        $teacherData = [
-            'institution_name' => $validated['institution_name'] ?? null,
-            'division' => $validated['division'] ?? null,
-            'district' => $validated['district'] ?? null,
-            'thana' => $validated['thana'] ?? null,
-            'phone' => $validated['phone'] ?? null,
-            'address' => $validated['address'] ?? null,
-            'teacher_profile_completed_at' => null,
-        ];
+        $teacherData = [];
 
         if ($role === Role::TEACHER) {
-            $teacherData['teacher_profile_completed_at'] = now();
+            $teacherData = [
+                'institution_name' => $validated['institution_name'],
+                'division' => $validated['division'],
+                'district' => $validated['district'],
+                'thana' => $validated['thana'],
+                'phone' => $validated['phone'],
+                'address' => $validated['address'],
+                'teacher_profile_completed_at' => now(),
+            ];
         }
 
         $user = User::create([


### PR DESCRIPTION
## Summary
- ensure social registration only attaches teacher profile details when the teacher role is selected
- keep student registrations free from unnecessary teacher-specific data requirements

## Testing
- `php artisan test --filter SocialiteRegistrationTest` *(blocked: missing Composer dependencies because `composer install` cannot access GitHub over HTTPS in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b33d19a48326a92231977a8ead2d