### PR TITLE
Make social registration teacher fields conditional

### DIFF
--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -121,14 +121,16 @@ class SocialiteController
             return redirect()->route('login')->with('status', __('Please start the :provider sign in process again.', ['provider' => ucfirst($provider)]));
         }
 
+        $teacherRole = Role::TEACHER->value;
+
         $validated = $request->validate([
-            'role' => ['required', Rule::in([Role::TEACHER->value, Role::STUDENT->value])],
-            'institution_name' => ['required_if:role,'.Role::TEACHER->value, 'string', 'max:255'],
-            'division' => ['required_if:role,'.Role::TEACHER->value, 'string', 'max:255'],
-            'district' => ['required_if:role,'.Role::TEACHER->value, 'string', 'max:255'],
-            'thana' => ['required_if:role,'.Role::TEACHER->value, 'string', 'max:255'],
-            'phone' => ['required_if:role,'.Role::TEACHER->value, 'string', 'max:30'],
-            'address' => ['required_if:role,'.Role::TEACHER->value, 'string', 'max:1000'],
+            'role' => ['required', Rule::in([$teacherRole, Role::STUDENT->value])],
+            'institution_name' => ['exclude_unless:role,'.$teacherRole, 'required', 'string', 'max:255'],
+            'division' => ['exclude_unless:role,'.$teacherRole, 'required', 'string', 'max:255'],
+            'district' => ['exclude_unless:role,'.$teacherRole, 'required', 'string', 'max:255'],
+            'thana' => ['exclude_unless:role,'.$teacherRole, 'required', 'string', 'max:255'],
+            'phone' => ['exclude_unless:role,'.$teacherRole, 'required', 'string', 'max:30'],
+            'address' => ['exclude_unless:role,'.$teacherRole, 'required', 'string', 'max:1000'],
         ]);
 
         $existingUser = User::where('email', $pending['email'])->first();


### PR DESCRIPTION
## Summary
- update the social registration validator to exclude teacher-specific fields when the selected role is not teacher
- keep the teacher onboarding data assignment limited to actual teacher registrations

## Testing
- ❌ `php artisan test` *(missing vendor/autoload; composer install requires a GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2bf1cf60483269e9770a2804569f1