### PR TITLE
Add ApexCharts activity analysis to teacher dashboard

### DIFF
--- a/app/Livewire/Teacher/Dashboard.php
+++ b/app/Livewire/Teacher/Dashboard.php
@@ -2,7 +2,9 @@
 
 namespace App\Livewire\Teacher;
 
+use Carbon\Carbon;
 use Livewire\Component;
+use Illuminate\Support\Collection;
 use App\Models\{Question, QuestionSet, Subject};
 
 class Dashboard extends Component
@@ -20,11 +22,14 @@ class Dashboard extends Component
             ->latest()
             ->get();
 
+        $activityTimeline = $this->buildActivityTimeline($user->id);
+
         return view('livewire.teacher.dashboard', [
             'questionCount' => $questionCount,
             'questionSetCount' => $questionSets->count(),
             'subjects' => $subjects,
             'questionSets' => $questionSets,
+            'activityTimeline' => $activityTimeline,
         ])->layout('layouts.admin', ['title' => 'Teacher Dashboard']);
     }
 
@@ -40,5 +45,40 @@ class Dashboard extends Component
         $questionSet->delete();
 
         session()->flash('success', 'প্রশ্ন সেটটি সফলভাবে মুছে ফেলা হয়েছে।');
+    }
+
+    /**
+     * Build the activity timeline (last six months) for questions and question sets.
+     */
+    protected function buildActivityTimeline(int $userId): Collection
+    {
+        $startDate = Carbon::now()->subMonths(5)->startOfMonth();
+        $endDate = Carbon::now()->endOfMonth();
+
+        $monthlyQuestionTotals = Question::where('user_id', $userId)
+            ->whereBetween('created_at', [$startDate, $endDate])
+            ->get()
+            ->groupBy(fn (Question $question) => $question->created_at->format('Y-m'))
+            ->map->count();
+
+        $monthlyQuestionSetTotals = QuestionSet::where('user_id', $userId)
+            ->whereBetween('created_at', [$startDate, $endDate])
+            ->get()
+            ->groupBy(fn (QuestionSet $questionSet) => $questionSet->created_at->format('Y-m'))
+            ->map->count();
+
+        $timeline = collect();
+
+        for ($cursor = $startDate->copy(); $cursor <= $endDate; $cursor->addMonth()) {
+            $monthKey = $cursor->format('Y-m');
+
+            $timeline->push([
+                'label' => $cursor->translatedFormat('M Y'),
+                'questions' => (int) ($monthlyQuestionTotals[$monthKey] ?? 0),
+                'question_sets' => (int) ($monthlyQuestionSetTotals[$monthKey] ?? 0),
+            ]);
+        }
+
+        return $timeline;
     }
 }


### PR DESCRIPTION
## Summary
- build a six-month activity timeline for the logged-in teacher and expose it to the dashboard view
- render a new monthly activity ApexCharts card alongside the existing subject analysis with localized totals
- refactor the dashboard script to initialise both charts and react to dark-mode changes consistently

## Testing
- php artisan test *(fails: missing Composer dependencies because GitHub OAuth token is required in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2ff7ed3d8832686826d718f944f87