### PR TITLE
Add extended Bangla font support to question tools

### DIFF
--- a/app/Livewire/Teacher/QuestionGenerator.php
+++ b/app/Livewire/Teacher/QuestionGenerator.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Teacher;
 use Livewire\Component;
 use Illuminate\Database\Eloquent\Builder;
 use App\Models\{Subject, SubSubject, Chapter, Question};
+use App\Support\Fonts;
 
 class QuestionGenerator extends Component
 {
@@ -359,7 +360,7 @@ class QuestionGenerator extends Component
 
     public function setFontFamily(string $font): void
     {
-        if (! in_array($font, ['Bangla', 'SolaimanLipi', 'Kalpurush', 'roman'], true)) {
+        if (! in_array($font, $this->allowedFontFamilies(), true)) {
             return;
         }
 
@@ -392,7 +393,31 @@ class QuestionGenerator extends Component
             'subSubjects' => $this->subSubjects,
             'chapters' => $this->chapters,
             'sortOptions' => $this->sortOptions(),
+            'fontOptions' => $this->fontFamilyOptions(),
         ])->layout('layouts.admin', ['title' => __('প্রশ্ন ক্রিয়েট')]);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function fontFamilyOptions(): array
+    {
+        return Fonts::options();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function allowedFontFamilies(): array
+    {
+        return Fonts::keys();
+    }
+
+    public function updatedFontFamily(string $value): void
+    {
+        if (! in_array($value, $this->allowedFontFamilies(), true)) {
+            $this->fontFamily = 'Bangla';
+        }
     }
 
     /**

--- a/app/Livewire/Teacher/QuestionPaper.php
+++ b/app/Livewire/Teacher/QuestionPaper.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Teacher;
 use Livewire\Component;
 use App\Models\QuestionSet;
 use Illuminate\Http\Request;
+use App\Support\Fonts;
 
 class QuestionPaper extends Component
 {
@@ -15,6 +16,7 @@ class QuestionPaper extends Component
     public $subject;
     public $subSubject;
     public $chapters;
+    public string $fontFamily = 'Bangla';
 
     public array $previewOptions = [
         'attachAnswerSheet' => false,
@@ -49,7 +51,15 @@ class QuestionPaper extends Component
 
     public function render()
     {
-        return view('livewire.teacher.question-paper')
-               ->layout('layouts.admin');
+        return view('livewire.teacher.question-paper', [
+            'fontOptions' => Fonts::options(),
+        ])->layout('layouts.admin');
+    }
+
+    public function updatedFontFamily(string $value): void
+    {
+        if (! in_array($value, Fonts::keys(), true)) {
+            $this->fontFamily = 'Bangla';
+        }
     }
 }

--- a/app/Support/Fonts.php
+++ b/app/Support/Fonts.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Support;
+
+class Fonts
+{
+    /**
+     * Get the list of available font families mapped to their human readable labels.
+     *
+     * @return array<string, string>
+     */
+    public static function options(): array
+    {
+        return [
+            'Bangla' => 'বাংলা (ডিফল্ট)',
+            'HindSiliguri' => 'হিন্দ শিলিগুড়ি',
+            'SolaimanLipi' => 'সোলাইমান লিপি',
+            'Kalpurush' => 'কালপুরুষ',
+            'Shurjo' => 'শূর্য (Shurjo)',
+            'roman' => 'Times New Roman',
+        ];
+    }
+
+    /**
+     * Get the list of keys for the supported font families.
+     *
+     * @return array<int, string>
+     */
+    public static function keys(): array
+    {
+        return array_keys(self::options());
+    }
+}

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -9,7 +9,7 @@
 @tailwind utilities;
 
 body {
-    font-family: 'Shurjo', 'Roboto', sans-serif;
+    font-family: 'Hind Siliguri', 'Shurjo', 'Kalpurush', 'SolaimanLipi', 'Roboto', sans-serif;
     font-size: 1rem;
     line-height: 1.5;
     -webkit-font-smoothing: antialiased;
@@ -56,4 +56,45 @@ body {
 .ts-control{
     padding-top: .5rem;
     padding-bottom: .5rem;
+}
+
+.qp-font-bangla,
+.bangla {
+    font-family: 'Hind Siliguri', 'Shurjo', 'Kalpurush', 'SolaimanLipi', 'Roboto', sans-serif;
+}
+
+.qp-font-hind-siliguri {
+    font-family: 'Hind Siliguri', 'Shurjo', 'Kalpurush', 'SolaimanLipi', 'Roboto', sans-serif;
+}
+
+.qp-font-solaiman {
+    font-family: 'SolaimanLipi', 'Hind Siliguri', 'Kalpurush', 'Shurjo', 'Roboto', sans-serif;
+}
+
+.qp-font-kalpurush {
+    font-family: 'Kalpurush', 'Hind Siliguri', 'Shurjo', 'SolaimanLipi', 'Roboto', sans-serif;
+}
+
+.qp-font-shurjo {
+    font-family: 'Shurjo', 'Hind Siliguri', 'Kalpurush', 'SolaimanLipi', 'Roboto', sans-serif;
+}
+
+.qp-font-roman {
+    font-family: 'Times New Roman', Times, serif;
+}
+
+.qp-text-left {
+    text-align: left;
+}
+
+.qp-text-center {
+    text-align: center;
+}
+
+.qp-text-right {
+    text-align: right;
+}
+
+.qp-text-justify {
+    text-align: justify;
 }

--- a/resources/css/fonts.css
+++ b/resources/css/fonts.css
@@ -1,3 +1,29 @@
+@import url('https://fonts.googleapis.com/css2?family=Hind+Siliguri:wght@400;500;600;700&display=swap');
+
+/* Kalpurush */
+@font-face {
+  font-family: 'Kalpurush';
+  src: url('https://fonts.maateen.me/kalpurush/font.woff2') format('woff2'),
+       url('https://fonts.maateen.me/kalpurush/Kalpurush.woff2') format('woff2'),
+       url('https://fonts.maateen.me/kalpurush/Kalpurush.woff') format('woff'),
+       url('https://fonts.maateen.me/kalpurush/Kalpurush.ttf') format('truetype');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+/* SolaimanLipi */
+@font-face {
+  font-family: 'SolaimanLipi';
+  src: url('https://fonts.maateen.me/solaiman-lipi/font.woff2') format('woff2'),
+       url('https://fonts.maateen.me/solaiman-lipi/SolaimanLipi.woff2') format('woff2'),
+       url('https://fonts.maateen.me/solaiman-lipi/SolaimanLipi.woff') format('woff'),
+       url('https://fonts.maateen.me/solaiman-lipi/SolaimanLipi.ttf') format('truetype');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
 /* Roboto */
 @font-face {
   font-family: 'Roboto';

--- a/resources/views/livewire/teacher/question-generator-copy.blade.php
+++ b/resources/views/livewire/teacher/question-generator-copy.blade.php
@@ -265,8 +265,10 @@
             $summary = $questionPaperSummary;
             $fontClassMap = [
                 'Bangla' => 'qp-font-bangla',
+                'HindSiliguri' => 'qp-font-hind-siliguri',
                 'SolaimanLipi' => 'qp-font-solaiman',
                 'Kalpurush' => 'qp-font-kalpurush',
+                'Shurjo' => 'qp-font-shurjo',
                 'roman' => 'qp-font-roman',
             ];
             $fontClass = $fontClassMap[$fontFamily] ?? 'qp-font-bangla';
@@ -541,13 +543,12 @@
                                                 </div>
                                             </div>
                                             <div class="bg-gray-100 my-1 p-2">
-                                                <div class="rounded  justify-between items-center">
+                                                <div class="rounded justify-between items-center">
                                                     <p class="bangla mb-1 text-center">ফন্ট পরিবর্তন</p>
-                                                    <select id="font-selector">
-                                                        <option value="Bangla">বাংলা</option>
-                                                        <option value="SolaimanLipi">সোলাইমান লিপি</option>
-                                                        <option value="Kalpurush">কালপুরুষ</option>
-                                                        <option value="roman">Times New Roman</option>
+                                                    <select id="font-selector" wire:model.live="fontFamily" class="w-full rounded-md border border-gray-300">
+                                                        @foreach($fontOptions as $value => $label)
+                                                            <option value="{{ $value }}">{{ $label }}</option>
+                                                        @endforeach
                                                     </select>
                                                 </div>
                                             </div>

--- a/resources/views/livewire/teacher/question-paper.blade.php
+++ b/resources/views/livewire/teacher/question-paper.blade.php
@@ -1,5 +1,17 @@
+@php
+    $fontClassMap = [
+        'Bangla' => 'qp-font-bangla',
+        'HindSiliguri' => 'qp-font-hind-siliguri',
+        'SolaimanLipi' => 'qp-font-solaiman',
+        'Kalpurush' => 'qp-font-kalpurush',
+        'Shurjo' => 'qp-font-shurjo',
+        'roman' => 'qp-font-roman',
+    ];
+    $fontClass = $fontClassMap[$fontFamily] ?? 'qp-font-bangla';
+@endphp
+
 <div class="table-bordered py-4 print:p-0 print:overflow-hidden bg-gray-100 min-h-[95vh] print:bg-white">
-    <div class="bangla flex flex-col lg:flex-row justify-center  gap-5  print:gap-0 mx-4 print:mx-0">
+    <div class="bangla flex flex-col lg:flex-row justify-center gap-5 print:gap-0 mx-4 print:mx-0 {{ $fontClass }}">
         <div class="print:hidden  flex gap-x-2 justify-between sticky top-12 lg:hidden  p-2 text-center z-10 bg-white">
             <button class="flex justify-center gap-1 items-center border py-1 px-2 bg-white rounded" tabindex="0">
                 <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 512 512" class="text-gray-600 text-xs" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg">
@@ -15,7 +27,7 @@
                 </svg><span>ডাউনলোড</span></button>
         </div>
         <div class="hidden fixed print:hidden lg:hidden left-0 top-0 z-[100] h-full bg-gray-900/50 w-screen -ml-20"></div>
-        <div class="print-area relative min-w-screen md:overflow-auto lg:w-[210mm]" style="font-family: Shurjo;">
+        <div class="print-area relative min-w-screen md:overflow-auto lg:w-[210mm] {{ $fontClass }}">
             <div class="bg-white mb-3 print:hidden border-t-2 border-emerald-500">
                 <p class="text-center font-bold bg-emerald-50 p-1">কুইক সেটিংস</p>
                 <div class=" p-2">
@@ -242,13 +254,12 @@
                                 </div>
                             </div>
                             <div class="bg-gray-100 my-1 p-2">
-                                <div class="rounded  justify-between items-center">
+                                <div class="rounded justify-between items-center">
                                     <p class="bangla mb-1 text-center">ফন্ট পরিবর্তন</p>
-                                    <select id="font-selector" class="w-full rounded-md border border-gray-300">
-                                        <option value="Bangla">বাংলা</option>
-                                        <option value="SolaimanLipi">সোলাইমান লিপি</option>
-                                        <option value="Kalpurush">কালপুরুষ</option>
-                                        <option value="roman">Times New Roman</option>
+                                    <select id="font-selector" wire:model.live="fontFamily" class="w-full rounded-md border border-gray-300">
+                                        @foreach($fontOptions as $value => $label)
+                                            <option value="{{ $value }}">{{ $label }}</option>
+                                        @endforeach
                                     </select>
                                 </div>
                             </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,7 +12,7 @@ export default {
     theme: {
         extend: {
             fontFamily: {
-                sans: ['Shurjo', 'Roboto', ...defaultTheme.fontFamily.sans],
+                sans: ['Hind Siliguri', 'Shurjo', 'Kalpurush', 'SolaimanLipi', 'Roboto', ...defaultTheme.fontFamily.sans],
             },
         },
     },


### PR DESCRIPTION
## Summary
- centralize available Bangla font metadata in a reusable support helper
- expose Hind Siliguri and Shurjo choices through the question generator and paper Livewire UIs
- register the new web fonts and matching Tailwind/CSS classes for consistent typography across previews

## Testing
- php artisan test *(fails: vendor autoloader missing because composer install requires GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d30a5ddde4832680b8efbfb47e1bda