### PR TITLE
Add configurable font settings from admin panel

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -8,8 +8,14 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+    --app-font-body: 'Hind Siliguri', 'Shurjo', 'Kalpurush', 'SolaimanLipi', 'Roboto', sans-serif;
+    --app-font-heading: 'Hind Siliguri', 'Shurjo', 'Kalpurush', 'SolaimanLipi', 'Roboto', sans-serif;
+    --tw-font-sans: var(--app-font-body);
+}
+
 body {
-    font-family: 'Hind Siliguri', 'Shurjo', 'Kalpurush', 'SolaimanLipi', 'Roboto', sans-serif;
+    font-family: var(--app-font-body, 'Hind Siliguri', 'Shurjo', 'Kalpurush', 'SolaimanLipi', 'Roboto', sans-serif);
     font-size: 1rem;
     line-height: 1.5;
     -webkit-font-smoothing: antialiased;
@@ -18,6 +24,15 @@ body {
     -webkit-text-size-adjust: 100%;
     -ms-text-size-adjust: 100%;
 
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    font-family: var(--app-font-heading, var(--app-font-body, 'Hind Siliguri', 'Shurjo', 'Kalpurush', 'SolaimanLipi', 'Roboto', sans-serif));
 }
 .table-bordered {
     border-collapse: collapse;
@@ -60,7 +75,7 @@ body {
 
 .qp-font-bangla,
 .bangla {
-    font-family: 'Hind Siliguri', 'Shurjo', 'Kalpurush', 'SolaimanLipi', 'Roboto', sans-serif;
+    font-family: var(--app-font-body, 'Hind Siliguri', 'Shurjo', 'Kalpurush', 'SolaimanLipi', 'Roboto', sans-serif);
 }
 
 .qp-font-hind-siliguri {

--- a/resources/views/components/settings/font-loader.blade.php
+++ b/resources/views/components/settings/font-loader.blade.php
@@ -1,0 +1,27 @@
+@php
+    $defaultStack = "'Hind Siliguri', 'Shurjo', 'Kalpurush', 'SolaimanLipi', 'Roboto', sans-serif";
+    $fontBody = trim((string) \App\Models\Setting::get('frontend_font_body', $defaultStack));
+    $fontHeading = trim((string) \App\Models\Setting::get('frontend_font_heading', $fontBody ?: $defaultStack));
+    $fontImportUrl = trim((string) \App\Models\Setting::get('frontend_font_import_url', ''));
+
+    if ($fontBody === '') {
+        $fontBody = $defaultStack;
+    }
+
+    if ($fontHeading === '') {
+        $fontHeading = $fontBody;
+    }
+
+    if ($fontImportUrl === '') {
+        $fontImportUrl = null;
+    }
+@endphp
+@if ($fontImportUrl)
+    <link rel="stylesheet" href="{{ $fontImportUrl }}">
+@endif
+<style>
+    :root {
+        --app-font-body: {{ $fontBody }};
+        --app-font-heading: {{ $fontHeading }};
+    }
+</style>

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -14,6 +14,7 @@
     </script>
     {{-- Vite Assets (app.css এবং app.js এখান থেকে লোড হবে) --}}
     @vite(['resources/css/app.css','resources/js/app.js'])
+    @include('components.settings.font-loader')
 
     @livewireStyles
     @stack('styles')

--- a/resources/views/layouts/frontend.blade.php
+++ b/resources/views/layouts/frontend.blade.php
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ $title ?? 'MCQ Bank' }}</title>
     @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @include('components.settings.font-loader')
 </head>
 <body class="font-sans antialiased text-gray-900 bg-gray-100">
     <header class="bg-white shadow">

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -7,12 +7,9 @@
 
         <title>{{ config('app.name', 'Laravel') }}</title>
 
-        <!-- Fonts -->
-        <link rel="preconnect" href="https://fonts.bunny.net">
-        <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
-
         <!-- Scripts -->
         @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @include('components.settings.font-loader')
     </head>
     <body class="font-sans text-gray-900 antialiased">
         <div class="min-h-screen flex flex-col sm:justify-center items-center pt-6 sm:pt-0 bg-gray-100">

--- a/resources/views/layouts/panel.blade.php
+++ b/resources/views/layouts/panel.blade.php
@@ -15,6 +15,7 @@
 
     {{-- Vite Assets --}}
     @vite(['resources/css/app.css','resources/js/app.js'])
+    @include('components.settings.font-loader')
 
     {{-- Livewire Styles --}}
     @livewireStyles

--- a/resources/views/livewire/admin/settings.blade.php
+++ b/resources/views/livewire/admin/settings.blade.php
@@ -145,6 +145,34 @@
                 <div class="text-red-600 text-sm">{{ $message }}</div>
             @enderror
         </div>
+        <div class="pt-4 border-t border-gray-200 dark:border-gray-700">
+            <h2 class="text-lg font-semibold mb-2">Font settings</h2>
+            <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">Customize the font family used across the website. Provide a comma separated font stack (e.g. <code class="bg-gray-100 dark:bg-gray-800 px-1 rounded">'Inter', 'Hind Siliguri', sans-serif</code>). Leave the heading font blank to reuse the body font.</p>
+            <div class="space-y-4">
+                <div>
+                    <label class="block text-sm font-medium mb-1">Body font stack</label>
+                    <textarea rows="2" wire:model.defer="font_body" class="input-field"></textarea>
+                    @error('font_body')
+                        <div class="text-red-600 text-sm">{{ $message }}</div>
+                    @enderror
+                </div>
+                <div>
+                    <label class="block text-sm font-medium mb-1">Heading font stack</label>
+                    <textarea rows="2" wire:model.defer="font_heading" class="input-field" placeholder="Optional"></textarea>
+                    @error('font_heading')
+                        <div class="text-red-600 text-sm">{{ $message }}</div>
+                    @enderror
+                </div>
+                <div>
+                    <label class="block text-sm font-medium mb-1">Font stylesheet URL</label>
+                    <input type="url" wire:model.defer="font_import_url" class="input-field" placeholder="https://fonts.googleapis.com/css2?...">
+                    @error('font_import_url')
+                        <div class="text-red-600 text-sm">{{ $message }}</div>
+                    @enderror
+                    <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Optional: provide a hosted stylesheet link (such as Google Fonts) so the selected fonts load automatically.</p>
+                </div>
+            </div>
+        </div>
         <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded">Save</button>
     </form>
 </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,7 +12,8 @@ export default {
     theme: {
         extend: {
             fontFamily: {
-                sans: ['Hind Siliguri', 'Shurjo', 'Kalpurush', 'SolaimanLipi', 'Roboto', ...defaultTheme.fontFamily.sans],
+                sans: ['var(--app-font-body)', 'Hind Siliguri', 'Shurjo', 'Kalpurush', 'SolaimanLipi', 'Roboto', ...defaultTheme.fontFamily.sans],
+                heading: ['var(--app-font-heading)', 'Hind Siliguri', 'Shurjo', 'Kalpurush', 'SolaimanLipi', 'Roboto', ...defaultTheme.fontFamily.sans],
             },
         },
     },


### PR DESCRIPTION
## Summary
- allow admins to manage body and heading font stacks plus an optional stylesheet URL from the settings page
- inject a shared font loader partial into every layout and update Tailwind to honor the configurable font variables
- switch global styles to CSS custom properties so the configured fonts are applied site-wide

## Testing
- php artisan test *(fails: vendor autoloader missing and composer install blocked by 403 network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d30fd0afb08326a432c8e3247d07b6