### PR TITLE
Fix sidebar collapse content offset

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -90,7 +90,7 @@ function initializeApp() {
     const sidebarCollapse = document.getElementById('sidebarCollapse');
     const sidebarToggle = document.getElementById('sidebarToggle');
     const overlay = document.getElementById('sidebar-overlay');
-    const mainContent = document.getElementById('mainContent');
+    const sidebarContent = document.querySelector('[data-sidebar-content]');
 
     function markActiveLinks() {
         if (!sidebar) return;
@@ -117,7 +117,7 @@ function initializeApp() {
     }
 
     function setSidebarState(collapsed) {
-        if (!sidebar || !mainContent) return;
+        if (!sidebar || !sidebarContent) return;
 
         const sidebarTextEls = document.querySelectorAll('.sidebar-text');
         const navLinks = document.querySelectorAll('.nav-link, .submenu-toggle');
@@ -126,8 +126,8 @@ function initializeApp() {
         if (collapsed) {
             sidebar.classList.remove('w-64');
             sidebar.classList.add('w-20');
-            mainContent.classList.remove('md:ml-64');
-            mainContent.classList.add('md:ml-20');
+            sidebarContent.classList.remove('md:ml-64');
+            sidebarContent.classList.add('md:ml-20');
             sidebarTextEls.forEach((el) => el.classList.add('hidden'));
             navLinks.forEach((link) => link.classList.add('justify-center'));
             submenus.forEach((menu) => {
@@ -143,8 +143,8 @@ function initializeApp() {
         } else {
             sidebar.classList.remove('w-20');
             sidebar.classList.add('w-64');
-            mainContent.classList.remove('md:ml-20');
-            mainContent.classList.add('md:ml-64');
+            sidebarContent.classList.remove('md:ml-20');
+            sidebarContent.classList.add('md:ml-64');
             sidebarTextEls.forEach((el) => el.classList.remove('hidden'));
             navLinks.forEach((link) => link.classList.remove('justify-center'));
             submenus.forEach((menu) => {

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -31,7 +31,7 @@
     <livewire:admin.partials.sidebar />
 
     {{-- Main Content Wrapper --}}
-    <div class="flex flex-1 flex-col min-w-0 w-full transition-all duration-300 md:ml-64">
+    <div data-sidebar-content class="flex flex-1 flex-col min-w-0 w-full transition-all duration-300 md:ml-64">
 
         {{-- Header --}}
         <livewire:admin.partials.header />

--- a/resources/views/layouts/panel.blade.php
+++ b/resources/views/layouts/panel.blade.php
@@ -21,7 +21,7 @@
 <div class="min-h-screen bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200">
     <livewire:admin.partials.sidebar />
 
-    <div id="mainContent" class="space-y-6 p-4 print:space-y-0 print:p-0 md:ml-64 md:p-8">
+    <div id="mainContent" data-sidebar-content class="space-y-6 p-4 print:space-y-0 print:p-0 md:ml-64 md:p-8">
         <livewire:admin.partials.header />
         {{ $slot }}
     </div>


### PR DESCRIPTION
### Motivation
- When the sidebar is collapsed the header and main content kept the larger left margin, leaving an unwanted blank area on the left of the page.
- The intent is to make the collapse/expand logic shift the entire layout wrapper (header + main) instead of only the inner `<main>` so the UI aligns correctly.

### Description
- Added a `data-sidebar-content` attribute to the admin layout wrapper (`resources/views/layouts/admin.blade.php`) and to the panel layout wrapper (`resources/views/layouts/panel.blade.php`).
- Replaced the JS reference to `#mainContent` with a query for `[data-sidebar-content]` in `resources/js/app.js` and updated the `md:ml-*` toggles to operate on that element instead of the inner `<main>`.
- Updated the sidebar collapse/expand checks to guard against missing `sidebar` or `data-sidebar-content` elements so the behavior is consistent across layouts.

### Testing
- Ran `npm run build` which completed successfully and produced the public build assets without build errors.
- Verified `git` shows the three modified files (`resources/js/app.js`, `resources/views/layouts/admin.blade.php`, `resources/views/layouts/panel.blade.php`) staged and committed.
- Manual UI verification was intended (collapse/expand behavior) and the JS changes target the full layout wrapper so header and main no longer keep the oversized left offset.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baecdc49f48321aecbd3dc96e76ef7)