### PR TITLE
Use `data-sidebar-content` and adjust sidebar collapse behavior for theme and actions

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -90,7 +90,7 @@ function initializeApp() {
     const sidebarCollapse = document.getElementById('sidebarCollapse');
     const sidebarToggle = document.getElementById('sidebarToggle');
     const overlay = document.getElementById('sidebar-overlay');
-    const mainContent = document.getElementById('mainContent');
+    const sidebarContent = document.querySelector('[data-sidebar-content]');
 
     function markActiveLinks() {
         if (!sidebar) return;
@@ -117,19 +117,28 @@ function initializeApp() {
     }
 
     function setSidebarState(collapsed) {
-        if (!sidebar || !mainContent) return;
+        if (!sidebar || !sidebarContent) return;
 
         const sidebarTextEls = document.querySelectorAll('.sidebar-text');
         const navLinks = document.querySelectorAll('.nav-link, .submenu-toggle');
         const submenus = document.querySelectorAll('.submenu');
+        const themePanels = document.querySelectorAll('[data-sidebar-theme-panel]');
+        const themeIconGroups = document.querySelectorAll('[data-sidebar-theme-icon-group]');
+        const sidebarActions = document.querySelectorAll('[data-sidebar-action]');
 
         if (collapsed) {
             sidebar.classList.remove('w-64');
             sidebar.classList.add('w-20');
-            mainContent.classList.remove('md:ml-64');
-            mainContent.classList.add('md:ml-20');
+            sidebarContent.classList.remove('md:ml-64');
+            sidebarContent.classList.add('md:ml-20');
             sidebarTextEls.forEach((el) => el.classList.add('hidden'));
             navLinks.forEach((link) => link.classList.add('justify-center'));
+            themePanels.forEach((panel) => {
+                panel.classList.remove('justify-between', 'px-4');
+                panel.classList.add('justify-center', 'px-2');
+            });
+            themeIconGroups.forEach((group) => group.classList.add('hidden'));
+            sidebarActions.forEach((action) => action.classList.add('justify-center'));
             submenus.forEach((menu) => {
                 const items = menu.querySelector('.submenu-items');
                 const arrow = menu.querySelector('.arrow');
@@ -143,10 +152,16 @@ function initializeApp() {
         } else {
             sidebar.classList.remove('w-20');
             sidebar.classList.add('w-64');
-            mainContent.classList.remove('md:ml-20');
-            mainContent.classList.add('md:ml-64');
+            sidebarContent.classList.remove('md:ml-20');
+            sidebarContent.classList.add('md:ml-64');
             sidebarTextEls.forEach((el) => el.classList.remove('hidden'));
             navLinks.forEach((link) => link.classList.remove('justify-center'));
+            themePanels.forEach((panel) => {
+                panel.classList.remove('justify-center', 'px-2');
+                panel.classList.add('justify-between', 'px-4');
+            });
+            themeIconGroups.forEach((group) => group.classList.remove('hidden'));
+            sidebarActions.forEach((action) => action.classList.remove('justify-center'));
             submenus.forEach((menu) => {
                 const items = menu.querySelector('.submenu-items');
                 const arrow = menu.querySelector('.arrow');

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -31,7 +31,7 @@
     <livewire:admin.partials.sidebar />
 
     {{-- Main Content Wrapper --}}
-    <div class="flex flex-1 flex-col min-w-0 w-full transition-all duration-300 md:ml-64">
+    <div data-sidebar-content class="flex flex-1 flex-col min-w-0 w-full transition-all duration-300 md:ml-64">
 
         {{-- Header --}}
         <livewire:admin.partials.header />

--- a/resources/views/layouts/panel.blade.php
+++ b/resources/views/layouts/panel.blade.php
@@ -21,7 +21,7 @@
 <div class="min-h-screen bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200">
     <livewire:admin.partials.sidebar />
 
-    <div id="mainContent" class="space-y-6 p-4 print:space-y-0 print:p-0 md:ml-64 md:p-8">
+    <div id="mainContent" data-sidebar-content class="space-y-6 p-4 print:space-y-0 print:p-0 md:ml-64 md:p-8">
         <livewire:admin.partials.header />
         {{ $slot }}
     </div>

--- a/resources/views/livewire/admin/partials/sidebar.blade.php
+++ b/resources/views/livewire/admin/partials/sidebar.blade.php
@@ -161,8 +161,8 @@
 
     <div class="px-4 py-4 border-t border-gray-100 dark:border-gray-800 space-y-2">
 
-        <div class="flex items-center justify-between rounded-xl bg-gray-50 px-4 py-3 dark:bg-gray-800/50">
-            <div class="flex items-center gap-3">
+        <div data-sidebar-theme-panel class="flex items-center justify-between rounded-xl bg-gray-50 px-4 py-3 dark:bg-gray-800/50">
+            <div data-sidebar-theme-icon-group class="flex items-center gap-3">
                 <x-heroicon-s-sun x-show="!isDark" class="h-5 w-5 text-gray-500" />
 
                 <x-heroicon-s-moon x-show="isDark" x-cloak class="h-5 w-5 text-indigo-400" />
@@ -181,7 +181,7 @@
 
         <form method="POST" action="{{ route('logout') }}" class="block">
             @csrf
-            <button type="submit" class="flex w-full items-center gap-3 rounded-xl px-4 py-3 text-[15px] font-medium text-red-500 transition-colors hover:bg-red-50 dark:hover:bg-red-500/10">
+            <button data-sidebar-action type="submit" class="flex w-full items-center gap-3 rounded-xl px-4 py-3 text-[15px] font-medium text-red-500 transition-colors hover:bg-red-50 dark:hover:bg-red-500/10">
                 <x-heroicon-s-arrow-right-start-on-rectangle class="h-5 w-5 flex-shrink-0" />
                 <span class="sidebar-text">Logout</span>
             </button>


### PR DESCRIPTION
### Motivation

- Ensure the sidebar collapse/expand logic targets the correct main content container via a stable data attribute instead of the `#mainContent` id.
- Make the sidebar's compact state visually consistent by collapsing theme controls and centering action buttons when the sidebar is reduced.
- Add explicit data attributes in Blade templates so the JavaScript can reliably find and adjust sidebar-related UI groups.

### Description

- Replace the `mainContent` DOM reference with `sidebarContent` and select it via `data-sidebar-content` in `resources/js/app.js`.
- Update `setSidebarState` to query and toggle classes for `[data-sidebar-theme-panel]`, `[data-sidebar-theme-icon-group]`, and `[data-sidebar-action]` so theme icons and action buttons are hidden/centered when collapsed.
- Add `data-sidebar-content` to the main wrappers in `resources/views/layouts/admin.blade.php` and `resources/views/layouts/panel.blade.php` and add `data-sidebar-theme-panel`, `data-sidebar-theme-icon-group`, and `data-sidebar-action` attributes in `resources/views/livewire/admin/partials/sidebar.blade.php`.
- Preserve existing submenu open/close and active-link handling while ensuring layout class changes apply to the correct container.

### Testing

- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baecdc49f48321aecbd3dc96e76ef7)