### PR TITLE
Apply selected paper size to question paper preview and print

### DIFF
--- a/resources/views/livewire/teacher/question-paper.blade.php
+++ b/resources/views/livewire/teacher/question-paper.blade.php
@@ -12,7 +12,40 @@
     // পেপার সাইজের ডাইনামিক মাপ
     $paperWidths = ['A4' => '210mm', 'Letter' => '215.9mm', 'Legal' => '215.9mm', 'A5' => '148mm'];
     $paperMinHeights = ['A4' => '297mm', 'Letter' => '279.4mm', 'Legal' => '355.6mm', 'A5' => '210mm'];
+    $selectedPaperWidth = $paperWidths[$paperSize] ?? $paperWidths['A4'];
+    $selectedPaperMinHeight = $paperMinHeights[$paperSize] ?? $paperMinHeights['A4'];
 @endphp
+
+<style>
+    @media screen {
+        .question-paper-preview {
+            width: min(100%, {{ $selectedPaperWidth }});
+            min-height: {{ $selectedPaperMinHeight }};
+            margin-left: auto;
+            margin-right: auto;
+        }
+    }
+
+    @media print {
+        @page {
+            size: {{ $selectedPaperWidth }} {{ $selectedPaperMinHeight }};
+            margin: 0;
+        }
+
+        html,
+        body {
+            width: {{ $selectedPaperWidth }};
+            min-height: {{ $selectedPaperMinHeight }};
+            background: #fff !important;
+        }
+
+        .question-paper-preview {
+            width: 100% !important;
+            min-height: {{ $selectedPaperMinHeight }};
+            margin: 0 !important;
+        }
+    }
+</style>
 
 <div class="table-bordered py-4 print:p-0 print:overflow-hidden bg-gray-100 min-h-[95vh] print:bg-white">
     <div class="bangla flex flex-col lg:flex-row justify-center gap-5 print:gap-0 mx-4 print:mx-0 {{ $fontClass }}">
@@ -31,14 +64,17 @@
                 </svg><span>ডাউনলোড</span></button>
         </div>
         <div class="hidden fixed print:hidden lg:hidden left-0 top-0 z-[100] h-full bg-gray-900/50 w-screen -ml-20"></div>
-        <div class="print-area relative min-w-screen md:overflow-auto lg:w-[210mm] {{ $fontClass }}">
+        <div
+            class="print-area question-paper-preview relative w-full max-w-full md:overflow-auto {{ $fontClass }}"
+            style="width: min(100%, {{ $selectedPaperWidth }}); min-height: {{ $selectedPaperMinHeight }};"
+        >
             <div class="bg-white mb-3 print:hidden border-t-2 border-emerald-500">
                 <p class="text-center font-bold bg-emerald-50 p-1">কুইক সেটিংস</p>
                 <div class=" p-2">
                     <a href="{{ route('questions.view', ['qset' => $questionSet->id]) }}" class="bg-emerald-600 hover:opacity-90 px-2 py-1 text-white ">+ আরও প্রশ্ন যুক্ত করুন</a>
                 </div>
             </div>
-            <div class=" w-full p-[5mm] md:p-[10mm] print:p-0.5 print:w-full print:shadow-none bg-white">
+            <div class="w-full bg-white p-[5mm] md:p-[10mm] print:w-full print:shadow-none print:p-[8mm]" style="min-height: {{ $selectedPaperMinHeight }};">
                 <div class="relative py-2 print:py-0">
                     <h1 class="text-xl font-bold text-center">{{ $instituteName }}</h1>
                     @if($previewOptions['showExamName'])


### PR DESCRIPTION
### Motivation
- Ensure the preview panel and browser print output respect the paper size chosen in the UI (A4/Letter/Legal/A5) instead of remaining fixed to A4.

### Description
- Compute `$selectedPaperWidth` and `$selectedPaperMinHeight` from the current `$paperSize` and expose them to the view for layout calculations.
- Add screen CSS `.question-paper-preview` so the on-screen preview container sizes and centers according to the selected paper width.
- Add print CSS with a dynamic `@page` size and set `html`, `body`, and preview container dimensions so print preview and the printed page follow the selected size.
- Update the `print-area` wrapper and inner printable container to bind dynamic `width`/`min-height` and adjust print padding to better match the selected page dimensions.

### Testing
- Ran `git diff --check` which succeeded with no whitespace/errors reported.
- Ran `php artisan view:cache` which failed because `vendor/autoload.php` is missing in this environment.
- Ran `php artisan test` which also failed for the same missing `vendor/autoload.php` dependency in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c03c013a5c8321b4115b3ccd9e18da)