### PR TITLE
Rename Chapter wording to Topic in Livewire views

### DIFF
--- a/resources/views/livewire/admin/chapters/index.blade.php
+++ b/resources/views/livewire/admin/chapters/index.blade.php
@@ -11,7 +11,7 @@
                     <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                         <svg class="h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd" /></svg>
                     </div>
-                    <input type="text" wire:model.live.debounce.300ms="search" placeholder="Search chapters..."
+                    <input type="text" wire:model.live.debounce.300ms="search" placeholder="Search topics..."
                            class="block w-full pl-10 pr-3 py-2.5 border border-gray-200 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 transition-shadow text-sm" />
                 </div>
 
@@ -27,7 +27,7 @@
             <button @click="showModal = true; $wire.openModal();"
                     class="inline-flex items-center justify-center gap-2 px-5 py-2.5 bg-indigo-600 text-white font-medium text-sm rounded-lg shadow-sm hover:bg-indigo-700 hover:shadow transition-all focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 shrink-0">
                 <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 448 512" height="1.1em" width="1.1em" xmlns="http://www.w3.org/2000/svg"><path d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"></path></svg>
-                New Chapter
+                New Topic
             </button>
         </div>
     </div>
@@ -37,7 +37,7 @@
             <thead>
             <tr class="bg-gray-50/80 dark:bg-gray-700/50 border-b border-gray-200 dark:border-gray-600 text-gray-500 dark:text-gray-300">
                 <th class="px-6 py-4 text-left font-semibold uppercase tracking-wider text-xs w-24">#ID</th>
-                <th class="px-6 py-4 text-left font-semibold uppercase tracking-wider text-xs">Chapter Name</th>
+                <th class="px-6 py-4 text-left font-semibold uppercase tracking-wider text-xs">Topic Name</th>
                 <th class="px-6 py-4 text-left font-semibold uppercase tracking-wider text-xs">Subject</th>
                 <th class="px-6 py-4 text-left font-semibold uppercase tracking-wider text-xs">Sub Subject</th>
                 <th class="px-6 py-4 text-right font-semibold uppercase tracking-wider text-xs w-32">Actions</th>
@@ -90,7 +90,7 @@
                                             }
                                         });
                                     } else {
-                                        if(confirm('Are you sure you want to delete this chapter?')) {
+                                        if(confirm('Are you sure you want to delete this topic?')) {
                                             $wire.delete({{ $chapter->id }});
                                         }
                                     }
@@ -105,7 +105,7 @@
                     <td colspan="5" class="px-6 py-12 text-center">
                         <div class="flex flex-col items-center justify-center text-gray-400 dark:text-gray-500">
                             <svg stroke="currentColor" fill="none" stroke-width="2" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" class="mb-3 text-gray-300 dark:text-gray-600" height="3em" width="3em" xmlns="http://www.w3.org/2000/svg"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20"></path></svg>
-                            <p class="text-lg font-medium">No chapters found</p>
+                            <p class="text-lg font-medium">No topics found</p>
                             <p class="text-sm mt-1">Try adjusting your search or filter to find what you're looking for.</p>
                         </div>
                     </td>
@@ -143,7 +143,7 @@
 
                 <div class="bg-gray-50 dark:bg-gray-700/50 px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
                     <h3 class="text-lg leading-6 font-bold text-gray-900 dark:text-white" id="modal-title">
-                        {{ $editId ? 'Edit Chapter' : 'Create New Chapter' }}
+                        {{ $editId ? 'Edit Topic' : 'Create New Topic' }}
                     </h3>
                     <button @click="showModal = false" class="text-gray-400 hover:text-gray-500 focus:outline-none">
                         <span class="sr-only">Close</span>
@@ -177,8 +177,8 @@
                         </div>
 
                         <div>
-                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Chapter Name <span class="text-red-500">*</span></label>
-                            <input type="text" wire:model="name" placeholder="e.g. Chapter 1: Motion" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200 dark:bg-gray-700 dark:text-white dark:border-gray-600">
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Topic Name <span class="text-red-500">*</span></label>
+                            <input type="text" wire:model="name" placeholder="e.g. Topic 1: Motion" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200 dark:bg-gray-700 dark:text-white dark:border-gray-600">
                             @error('name') <span class="text-xs text-red-500 mt-1 block">{{ $message }}</span> @enderror
                         </div>
 
@@ -190,7 +190,7 @@
                         </button>
                         <button type="submit" class="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 flex items-center gap-2">
                             <svg wire:loading wire:target="save" class="animate-spin h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
-                            <span wire:loading.remove wire:target="save">{{ $editId ? 'Update Chapter' : 'Save Chapter' }}</span>
+                            <span wire:loading.remove wire:target="save">{{ $editId ? 'Update Topic' : 'Save Topic' }}</span>
                             <span wire:loading wire:target="save">{{ $editId ? 'Updating...' : 'Saving...' }}</span>
                         </button>
                     </div>
@@ -223,7 +223,7 @@
 
         // Delete এর পর টোস্ট দেখানো
         window.addEventListener('chapterDeleted', e => {
-            showToast(e.detail.message || 'Chapter has been deleted successfully.');
+            showToast(e.detail.message || 'Topic has been deleted successfully.');
         });
     </script>
 @endpush

--- a/resources/views/livewire/admin/partials/sidebar.blade.php
+++ b/resources/views/livewire/admin/partials/sidebar.blade.php
@@ -93,7 +93,7 @@
                     </a>
                     <a wire:navigate href="{{ route('admin.chapters.index') }}"
                        class="{{ $submenuLinkClasses }} {{ request()->is('admin/chapters*') ? $submenuActiveClasses : '' }}">
-                        <span class="sidebar-text">Chapters</span>
+                        <span class="sidebar-text">Topics</span>
                     </a>
                     <a wire:navigate href="{{ route('admin.tags.index') }}"
                        class="{{ $submenuLinkClasses }} {{ request()->is('admin/tags*') ? $submenuActiveClasses : '' }}">

--- a/resources/views/livewire/admin/questions.blade.php
+++ b/resources/views/livewire/admin/questions.blade.php
@@ -21,7 +21,7 @@
 
                 <select wire:model.live="chapterId"
                         class="px-4 py-2.5 border border-gray-200 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 text-sm font-medium text-gray-600 bg-white">
-                    <option value="">All Chapters</option>
+                    <option value="">All Topics</option>
                     @foreach($chapters as $ch)
                         <option value="{{ $ch->id }}">{{ $ch->name }}</option>
                     @endforeach

--- a/resources/views/livewire/admin/questions/_form.blade.php
+++ b/resources/views/livewire/admin/questions/_form.blade.php
@@ -42,9 +42,9 @@
                 </div>
 
                 <div wire:ignore wire:key="chapter-select-{{ $question->id ?? 'create' }}">
-                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Chapter</label>
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Topic</label>
                     <select id="chapter" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-700 dark:text-gray-200">
-                        <option value="">-- Select Chapter --</option>
+                        <option value="">-- Select Topic --</option>
                         @foreach($chapters as $c) <option value="{{ $c->id }}" @selected($c->id == $chapter_id)>{{ $c->name }}</option> @endforeach
                     </select>
                 </div>
@@ -443,7 +443,7 @@
                 if (window.tsChapter) {
                     window.tsChapter.clear(true);
                     window.tsChapter.clearOptions();
-                    window.tsChapter.addOption({value: '', text: '-- Select Chapter --'});
+                    window.tsChapter.addOption({value: '', text: '-- Select Topic --'});
                     window.tsChapter.addOptions(e.detail.chapters);
                     window.tsChapter.refreshOptions(false);
                 }

--- a/resources/views/livewire/admin/questions/question-form.blade.php
+++ b/resources/views/livewire/admin/questions/question-form.blade.php
@@ -22,9 +22,9 @@
             </select>
         </div>
 
-        {{-- Chapter (Optional) --}}
+        {{-- Topic (Optional) --}}
         <div>
-            <label>Chapter (Optional)</label>
+            <label>Topic (Optional)</label>
             <select wire:model="chapter_id" class="border p-2 rounded w-full" {{ $sub_subject_id ? '' : 'disabled' }}>
                 <option value="">-- Select --</option>
                 @foreach($chapters as $c)

--- a/resources/views/livewire/practice.blade.php
+++ b/resources/views/livewire/practice.blade.php
@@ -7,7 +7,7 @@
             @endforeach
         </select>
         <select wire:model.live="chapterId" class="border rounded px-3 py-2">
-            <option value="">All Chapters</option>
+            <option value="">All Topics</option>
             @foreach($chapters as $chapter)
                 <option value="{{ $chapter->id }}">{{ $chapter->name }}</option>
             @endforeach

--- a/resources/views/livewire/student/exam.blade.php
+++ b/resources/views/livewire/student/exam.blade.php
@@ -16,7 +16,7 @@
             </select>
 
             <select wire:model="chapterId" class="w-full border rounded px-3 py-2">
-                <option value="">অধ্যায় সিলেক্ট করো</option>
+                <option value="">টপিক সিলেক্ট করো</option>
                 @foreach($chapters as $chapter)
                     <option value="{{ $chapter->id }}">{{ $chapter->name }}</option>
                 @endforeach

--- a/resources/views/livewire/teacher/question-generator-copy.blade.php
+++ b/resources/views/livewire/teacher/question-generator-copy.blade.php
@@ -64,11 +64,11 @@
                 </div>
 
                 <div>
-                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1" for="chapter">অধ্যায়</label>
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1" for="chapter">টপিক</label>
                     <select id="chapter" wire:model="chapterId"
                             class="w-full rounded border-gray-300 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 focus:border-indigo-500 focus:ring-indigo-500"
                             @disabled(empty($chapters))>
-                        <option value="">সমস্ত অধ্যায়</option>
+                        <option value="">সমস্ত টপিক</option>
                         @foreach($chapters as $chapter)
                             <option value="{{ $chapter['id'] }}">{{ $chapter['name'] }}</option>
                         @endforeach
@@ -446,7 +446,7 @@
                                                 </label>
                                             </div>
                                             <div class="bg-gray-100 p-2 rounded  flex justify-between items-center my-1">
-                                                <span class="bangla">অধ্যায়ের নাম</span>
+                                                <span class="bangla">টপিকের নাম</span>
                                                 <label class="relative inline-flex items-center  cursor-pointer">
                                                     <input type="checkbox" class="sr-only peer" checked="" wire:model.live="previewOptions.showChapter">
                                                     <div class="w-11 h-6 bg-gray-200 rounded-full peerdark:peer-focus:ring-emerald-800 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-emerald-600"></div>

--- a/resources/views/livewire/teacher/question-generator.blade.php
+++ b/resources/views/livewire/teacher/question-generator.blade.php
@@ -5617,7 +5617,7 @@
                         <div class="my-2">
                             <div class="bg-white border rounded-lg my-4">
                                 <div class="p-2 bg-gray-100 ">
-                                    <p class="font-bold">টপিক - <span class="font-normal truncate">অধ্যায় ১ - বাস্তব সংখ্যা</span>
+                                    <p class="font-bold">টপিক - <span class="font-normal truncate">টপিক ১ - বাস্তব সংখ্যা</span>
                                     </p>
                                 </div>
                                 <div class="border-t text-gray-700">

--- a/resources/views/livewire/teacher/question-paper-copy.blade.php
+++ b/resources/views/livewire/teacher/question-paper-copy.blade.php
@@ -6,7 +6,7 @@
 
         <div class="text-lg text-gray-600 mt-2">
             <p>বিষয়: {{ $subSubject->name ?? 'N/A' }} {{ $subSubject->name ? '(' . $subject->name . ')' : '' }}</p>
-            <p>অধ্যায়: {{ $chapter->name }}</p>
+            <p>টপিক: {{ $chapter->name }}</p>
         </div>
     </div>
 


### PR DESCRIPTION
### Motivation
- Update user-facing terminology from “Chapter/Chapters/অধ্যায়” to “Topic/Topics/টপিক” across the Livewire Blade templates to match the desired wording while keeping data/model names unchanged.
- Preserve existing routes, variables and backend behavior so only presentation text is changed.

### Description
- Replaced English labels/placeholders/button text such as `Chapter`, `Chapters`, `New Chapter`, `All Chapters`, and related empty-state and confirmation strings with `Topic`/`Topics` across multiple Blade templates under `resources/views/livewire`.
- Replaced Bangla occurrences of `অধ্যায়` with `টপিক` in student/teacher views and preview UI elements.
- Updated TomSelect default option text and other small JS-driven option labels (e.g. `-- Select Chapter --` → `-- Select Topic --`) so selector UIs show the new wording.
- No changes were made to route names, model/column names, Livewire public properties (e.g. `chapterId`, `chapter_id`) or controller logic.

### Testing
- Attempted to run the PHPUnit filter `php artisan test --filter QuestionChapterOptionalTest` but the run failed in this environment due to a missing `vendor/autoload.php` (tests did not execute here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c56642e5b083219c5532b1de4569c7)