### PR TITLE
Rename SubSubject → Chapter across models, migrations, Livewire, views and routes

### DIFF
--- a/app/Livewire/Admin/Chapters/Index.php
+++ b/app/Livewire/Admin/Chapters/Index.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace App\Livewire\Admin\SubSubjects;
+namespace App\Livewire\Admin\Chapters;
 
 use Livewire\Component;
 use Livewire\WithPagination;
-use App\Models\SubSubject;
+use App\Models\Chapter;
 use App\Models\Subject;
 use Illuminate\Validation\Rule;
 
@@ -25,7 +25,7 @@ class Index extends Component
     public $modalSubjectId = '';
     public $editId = null; // এডিট করার জন্য আইডি ট্র্যাক করবে
 
-    protected $listeners = ['deleteSubSubjectConfirmed' => 'delete'];
+    protected $listeners = ['deleteChapterConfirmed' => 'delete'];
 
     public function updatingSearch()
     {
@@ -46,7 +46,7 @@ class Index extends Component
     }
 
     // ক্লোন করার মূল লজিক
-    public function cloneSubSubjects()
+    public function cloneChapters()
     {
         $this->validate([
             'cloneSourceSubjectId' => 'required|exists:subjects,id',
@@ -56,22 +56,22 @@ class Index extends Component
         ]);
 
         // সোর্স সাবজেক্টের সব সাব-সাবজেক্ট খুঁজে বের করা
-        $subSubjectsToCopy = SubSubject::where('subject_id', $this->cloneSourceSubjectId)->get();
+        $chaptersToCopy = Chapter::where('subject_id', $this->cloneSourceSubjectId)->get();
 
-        if ($subSubjectsToCopy->isEmpty()) {
+        if ($chaptersToCopy->isEmpty()) {
             $this->addError('cloneSourceSubjectId', 'এই সাবজেক্টে কপি করার মতো কোনো সাব-সাবজেক্ট নেই!');
             return;
         }
 
         $count = 0;
-        foreach ($subSubjectsToCopy as $sub) {
+        foreach ($chaptersToCopy as $sub) {
             // আগে চেক করা হবে টার্গেট সাবজেক্টে একই নামের কিছু আছে কি না
-            $exists = SubSubject::where('subject_id', $this->cloneTargetSubjectId)
+            $exists = Chapter::where('subject_id', $this->cloneTargetSubjectId)
                 ->where('name', $sub->name)
                 ->exists();
 
             if (!$exists) {
-                SubSubject::create([
+                Chapter::create([
                     'subject_id' => $this->cloneTargetSubjectId,
                     'name' => $sub->name,
                 ]);
@@ -81,7 +81,7 @@ class Index extends Component
 
         $this->showCloneModal = false;
         $this->resetPage(); // টেবিল রিফ্রেশ করার জন্য
-        $this->dispatch('subSubjectSaved', message: "{$count} টি সাব-সাবজেক্ট সফলভাবে কপি হয়েছে!");
+        $this->dispatch('chapterSaved', message: "{$count} টি সাব-সাবজেক্ট সফলভাবে কপি হয়েছে!");
     }
 
 
@@ -96,11 +96,11 @@ class Index extends Component
     public function edit($id)
     {
         $this->resetValidation();
-        $subSubject = SubSubject::findOrFail($id);
+        $chapter = Chapter::findOrFail($id);
 
-        $this->editId = $subSubject->id;
-        $this->modalSubjectId = $subSubject->subject_id;
-        $this->name = $subSubject->name;
+        $this->editId = $chapter->id;
+        $this->modalSubjectId = $chapter->subject_id;
+        $this->name = $chapter->name;
 
         // মডাল ওপেন করার ইভেন্ট পাঠানো হচ্ছে
         $this->dispatch('open-modal');
@@ -114,7 +114,7 @@ class Index extends Component
             'name' => [
                 'required',
                 'string',
-                Rule::unique('sub_subjects', 'name')
+                Rule::unique('chapters', 'name')
                     ->where('subject_id', $this->modalSubjectId)
                     ->ignore($this->editId) // আপডেটের সময় নিজের আইডি ইগনোর করবে যাতে এরর না দেয়
             ],
@@ -122,15 +122,15 @@ class Index extends Component
 
         if ($this->editId) {
             // যদি editId থাকে, তবে ডেটা আপডেট হবে
-            $subSubject = SubSubject::find($this->editId);
-            $subSubject->update([
+            $chapter = Chapter::find($this->editId);
+            $chapter->update([
                 'subject_id' => $this->modalSubjectId,
                 'name' => $this->name,
             ]);
             $message = 'Sub subject updated successfully!';
         } else {
             // editId না থাকলে নতুন তৈরি হবে
-            SubSubject::create([
+            Chapter::create([
                 'subject_id' => $this->modalSubjectId,
                 'name' => $this->name,
             ]);
@@ -142,22 +142,22 @@ class Index extends Component
 
         // মডাল বন্ধ করার জন্য ব্রাউজারে ইভেন্ট পাঠানো
         $this->dispatch('close-modal');
-        $this->dispatch('subSubjectSaved', message: $message);
+        $this->dispatch('chapterSaved', message: $message);
     }
 
     // ডিলিট করার মেথড
     public function delete($id)
     {
-        $subSubject = \App\Models\SubSubject::find($id);
-        if ($subSubject) {
-            $subSubject->delete();
-            $this->dispatch('subSubjectDeleted', message: 'Sub subject deleted successfully.');
+        $chapter = \App\Models\Chapter::find($id);
+        if ($chapter) {
+            $chapter->delete();
+            $this->dispatch('chapterDeleted', message: 'Sub subject deleted successfully.');
         }
     }
 
     public function render()
     {
-        $query = SubSubject::query()->with('subject');
+        $query = Chapter::query()->with('subject');
 
         if ($this->search) {
             $query->where('name', 'like', '%' . $this->search . '%');
@@ -167,9 +167,9 @@ class Index extends Component
             $query->where('subject_id', $this->subjectId);
         }
 
-        return view('livewire.admin.sub-subjects.index', [
-            'subSubjects' => $query->latest()->paginate(10),
+        return view('livewire.admin.chapters.index', [
+            'chapters' => $query->latest()->paginate(10),
             'subjects' => Subject::orderBy('name')->get(), // ফিল্টার এবং মডাল উভয়ের জন্য
-        ])->layout('layouts.admin', ['title' => 'Sub Subjects']);
+        ])->layout('layouts.admin', ['title' => 'Chapters']);
     }
 }

--- a/app/Livewire/Admin/Questions/Create.php
+++ b/app/Livewire/Admin/Questions/Create.php
@@ -6,7 +6,7 @@ use App\Livewire\Traits\SlugValidationTrait;
 use Livewire\Component;
 use Livewire\WithFileUploads; // Image Upload এর জন্য
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
-use App\Models\{Subject, SubSubject, Topic, Question, Tag, ExamCategory};
+use App\Models\{Subject, Chapter, Topic, Question, Tag, ExamCategory};
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 
@@ -14,7 +14,7 @@ class Create extends Component
 {
     use AuthorizesRequests, SlugValidationTrait, WithFileUploads; // WithFileUploads যুক্ত করা হলো
 
-    public $subject_id, $sub_subject_id, $topic_id, $title, $description, $difficulty = 'easy', $question_type = 'mcq', $marks = 1, $tagIds = [];
+    public $subject_id, $chapter_id, $topic_id, $title, $description, $difficulty = 'easy', $question_type = 'mcq', $marks = 1, $tagIds = [];
     public $options = [];
     public $cq = [];
     public $slug;
@@ -28,7 +28,7 @@ class Create extends Component
 
     public function resetFields(): void
     {
-        $this->reset('subject_id', 'sub_subject_id', 'topic_id', 'title', 'description', 'difficulty', 'question_type', 'marks', 'tagIds', 'options', 'cq', 'slug', 'exam_category_ids', 'image');
+        $this->reset('subject_id', 'chapter_id', 'topic_id', 'title', 'description', 'difficulty', 'question_type', 'marks', 'tagIds', 'options', 'cq', 'slug', 'exam_category_ids', 'image');
         $this->difficulty = 'easy';
         $this->question_type = 'mcq';
         $this->marks = 1;
@@ -131,18 +131,18 @@ class Create extends Component
 
     public function updatedSubjectId($value)
     {
-        $this->sub_subject_id = null;
+        $this->chapter_id = null;
         $this->topic_id = null;
-        $subSubjects = SubSubject::where('subject_id', $value)->get()->map(fn($s) => ['value' => $s->id, 'text' => $s->name])->all();
-        $this->dispatch('subSubjectsUpdated', subSubjects: $subSubjects);
+        $chapters = Chapter::where('subject_id', $value)->get()->map(fn($s) => ['value' => $s->id, 'text' => $s->name])->all();
+        $this->dispatch('chaptersUpdated', chapters: $chapters);
 
         $this->dispatch('topicsUpdated', topics: []);
     }
 
-    public function updatedSubSubjectId($value)
+    public function updatedChapterId($value)
     {
         $this->topic_id = null;
-        $topics = $value ? Topic::where('sub_subject_id', $value)->get()->map(fn($c) => ['value' => $c->id, 'text' => $c->name])->all() : [];
+        $topics = $value ? Topic::where('chapter_id', $value)->get()->map(fn($c) => ['value' => $c->id, 'text' => $c->name])->all() : [];
         $this->dispatch('topicsUpdated', topics: $topics);
     }
 
@@ -152,8 +152,8 @@ class Create extends Component
 
         $rules = [
             'subject_id' => 'required|exists:subjects,id',
-            'sub_subject_id' => 'nullable|exists:sub_subjects,id',
-            'topic_id' => 'required_with:sub_subject_id|nullable|exists:topics,id',
+            'chapter_id' => 'nullable|exists:chapters,id',
+            'topic_id' => 'required_with:chapter_id|nullable|exists:topics,id',
             'title' => 'required|string',
             'description' => 'nullable|string',
             'difficulty' => 'required|in:easy,medium,hard',
@@ -191,7 +191,7 @@ class Create extends Component
 
             $question = Question::create([
                 'subject_id' => $this->subject_id,
-                'sub_subject_id' => $this->sub_subject_id ?: null,
+                'chapter_id' => $this->chapter_id ?: null,
                 'topic_id' => $this->topic_id ?: null,
                 'title' => $this->title,
                 'slug' => $this->slug,
@@ -224,8 +224,8 @@ class Create extends Component
         $layout = auth()->user()->isAdmin() ? 'layouts.admin' : 'layouts.panel';
         return view('livewire.admin.questions.create', [
             'subjects' => Subject::all(),
-            'subSubjects' => SubSubject::where('subject_id', $this->subject_id)->get(),
-            'topics' => Topic::where('sub_subject_id', $this->sub_subject_id)->get(),
+            'chapters' => Chapter::where('subject_id', $this->subject_id)->get(),
+            'topics' => Topic::where('chapter_id', $this->chapter_id)->get(),
             'allTags' => Tag::all(),
             'allExamCategories' => ExamCategory::all(), // টার্গেট ক্যাটাগরি পাঠানো হলো
         ])->layout($layout, ['title' => 'Create Question']);

--- a/app/Livewire/Admin/Questions/Edit.php
+++ b/app/Livewire/Admin/Questions/Edit.php
@@ -6,7 +6,7 @@ use App\Livewire\Traits\SlugValidationTrait;
 use Livewire\Component;
 use Livewire\WithFileUploads; // Image Upload এর জন্য
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
-use App\Models\{Subject, SubSubject, Topic, Question, Tag, ExamCategory};
+use App\Models\{Subject, Chapter, Topic, Question, Tag, ExamCategory};
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\Storage; // Image delete এর জন্য
@@ -16,7 +16,7 @@ class Edit extends Component
     use AuthorizesRequests, SlugValidationTrait, WithFileUploads; // WithFileUploads যুক্ত করা হলো
 
     public Question $question;
-    public $subject_id, $sub_subject_id, $topic_id, $title, $description, $difficulty, $question_type = 'mcq', $marks = 1, $tagIds = [], $options = [];
+    public $subject_id, $chapter_id, $topic_id, $title, $description, $difficulty, $question_type = 'mcq', $marks = 1, $tagIds = [], $options = [];
     public $cq = [];
     public $slug;
     public $exam_category_ids = [];
@@ -29,7 +29,7 @@ class Edit extends Component
         $this->question = $question;
 
         $this->subject_id = $question->subject_id;
-        $this->sub_subject_id = $question->sub_subject_id;
+        $this->chapter_id = $question->chapter_id;
         $this->topic_id = $question->topic_id;
         $this->title = $question->title;
         $this->slug = $question->slug;
@@ -164,17 +164,17 @@ class Edit extends Component
 
     public function updatedSubjectId($value)
     {
-        $this->sub_subject_id = null;
+        $this->chapter_id = null;
         $this->topic_id = null;
-        $subSubjects = SubSubject::where('subject_id', $value)->get()->map(fn($s) => ['value' => $s->id, 'text' => $s->name])->all();
-        $this->dispatch('subSubjectsUpdated', subSubjects: $subSubjects);
+        $chapters = Chapter::where('subject_id', $value)->get()->map(fn($s) => ['value' => $s->id, 'text' => $s->name])->all();
+        $this->dispatch('chaptersUpdated', chapters: $chapters);
         $this->dispatch('topicsUpdated', topics: []);
     }
 
-    public function updatedSubSubjectId($value)
+    public function updatedChapterId($value)
     {
         $this->topic_id = null;
-        $topics = $value ? Topic::where('sub_subject_id', $value)->get()->map(fn($c) => ['value' => $c->id, 'text' => $c->name])->all() : [];
+        $topics = $value ? Topic::where('chapter_id', $value)->get()->map(fn($c) => ['value' => $c->id, 'text' => $c->name])->all() : [];
         $this->dispatch('topicsUpdated', topics: $topics);
     }
 
@@ -193,8 +193,8 @@ class Edit extends Component
 
         $rules = [
             'subject_id' => 'required|exists:subjects,id',
-            'sub_subject_id' => 'nullable|exists:sub_subjects,id',
-            'topic_id' => 'required_with:sub_subject_id|nullable|exists:topics,id',
+            'chapter_id' => 'nullable|exists:chapters,id',
+            'topic_id' => 'required_with:chapter_id|nullable|exists:topics,id',
             'title' => 'required|string',
             'description' => 'nullable|string',
             'difficulty' => 'required|in:easy,medium,hard',
@@ -235,7 +235,7 @@ class Edit extends Component
 
             $this->question->update([
                 'subject_id' => $this->subject_id,
-                'sub_subject_id' => $this->sub_subject_id ?: null,
+                'chapter_id' => $this->chapter_id ?: null,
                 'topic_id' => $this->topic_id ?: null,
                 'title' => $this->title,
                 'slug' => $this->slug,
@@ -267,8 +267,8 @@ class Edit extends Component
         $layout = auth()->user()->isAdmin() ? 'layouts.admin' : 'layouts.panel';
         return view('livewire.admin.questions.edit', [
             'subjects' => Subject::all(),
-            'subSubjects' => SubSubject::where('subject_id', $this->subject_id)->get(),
-            'topics' => Topic::where('sub_subject_id', $this->sub_subject_id)->get(),
+            'chapters' => Chapter::where('subject_id', $this->subject_id)->get(),
+            'topics' => Topic::where('chapter_id', $this->chapter_id)->get(),
             'allTags' => Tag::all(),
             'allExamCategories' => ExamCategory::all(), // টার্গেট ক্যাটাগরি পাঠানো হলো
         ])->layout($layout, ['title' => 'Edit Question']);

--- a/app/Livewire/Admin/Questions/QuestionForm.php
+++ b/app/Livewire/Admin/Questions/QuestionForm.php
@@ -4,20 +4,20 @@ namespace App\Livewire\Admin\Questions;
 
 use Livewire\Component;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
-use App\Models\{Subject, SubSubject, Topic, Question, Tag};
+use App\Models\{Subject, Chapter, Topic, Question, Tag};
 
 class QuestionForm extends Component
 {
     use AuthorizesRequests;
 
     public $questionId;  // যদি edit হয় তাহলে এই আইডি আসবে
-    public $subject_id, $sub_subject_id, $topic_id, $title, $difficulty = 'easy', $question_type = 'mcq', $marks = 1, $tagIds = [];
+    public $subject_id, $chapter_id, $topic_id, $title, $difficulty = 'easy', $question_type = 'mcq', $marks = 1, $tagIds = [];
     public $options = [];
 
     public function mount($id = null)
     {
         $this->subject_id = '';
-        $this->sub_subject_id = '';
+        $this->chapter_id = '';
         $this->topic_id = '';
 
         if ($id) {
@@ -27,7 +27,7 @@ class QuestionForm extends Component
             $this->authorize('update', $q);
 
             $this->subject_id = $q->subject_id;
-            $this->sub_subject_id = $q->sub_subject_id;
+            $this->chapter_id = $q->chapter_id;
             $this->topic_id = $q->topic_id;
             $this->title = $q->title;
             $this->difficulty = $q->difficulty;
@@ -64,11 +64,11 @@ class QuestionForm extends Component
 
     public function updatedSubjectId()
     {
-        $this->sub_subject_id = '';
+        $this->chapter_id = '';
         $this->topic_id = '';
     }
 
-    public function updatedSubSubjectId()
+    public function updatedChapterId()
     {
         $this->topic_id = '';
     }
@@ -77,8 +77,8 @@ class QuestionForm extends Component
     {
         $rules = [
             'subject_id' => 'required|exists:subjects,id',
-            'sub_subject_id' => 'nullable|exists:sub_subjects,id',
-            'topic_id' => 'required_with:sub_subject_id|nullable|exists:topics,id',
+            'chapter_id' => 'nullable|exists:chapters,id',
+            'topic_id' => 'required_with:chapter_id|nullable|exists:topics,id',
             'title' => 'required|string',
             'difficulty' => 'required|in:easy,medium,hard',
             'question_type' => 'required|in:mcq,cq,short',
@@ -104,7 +104,7 @@ class QuestionForm extends Component
             $this->authorize('update', $q);
             $q->update([
                 'subject_id' => $this->subject_id,
-                'sub_subject_id' => $this->sub_subject_id ?: null,
+                'chapter_id' => $this->chapter_id ?: null,
                 'topic_id' => $this->topic_id ?: null,
                 'title' => $this->title,
                 'difficulty' => $this->difficulty,
@@ -120,7 +120,7 @@ class QuestionForm extends Component
             $this->authorize('create', Question::class);
             $q = Question::create([
                 'subject_id' => $this->subject_id,
-                'sub_subject_id' => $this->sub_subject_id ?: null,
+                'chapter_id' => $this->chapter_id ?: null,
                 'topic_id' => $this->topic_id ?: null,
                 'title' => $this->title,
                 'difficulty' => $this->difficulty,
@@ -143,8 +143,8 @@ class QuestionForm extends Component
     {
         return view('livewire.admin.questions.question-form', [
             'subjects' => Subject::all(),
-            'subSubjects' => $this->subject_id ? SubSubject::where('subject_id', $this->subject_id)->get() : collect(),
-            'topics' => $this->sub_subject_id ? Topic::where('sub_subject_id', $this->sub_subject_id)->get() : collect(),
+            'chapters' => $this->subject_id ? Chapter::where('subject_id', $this->subject_id)->get() : collect(),
+            'topics' => $this->chapter_id ? Topic::where('chapter_id', $this->chapter_id)->get() : collect(),
             'allTags' => Tag::all(),
         ]);
     }

--- a/app/Livewire/Admin/Topics/Index.php
+++ b/app/Livewire/Admin/Topics/Index.php
@@ -6,7 +6,7 @@ use Livewire\Component;
 use Livewire\WithPagination;
 use App\Models\Topic;
 use App\Models\Subject;
-use App\Models\SubSubject;
+use App\Models\Chapter;
 use Illuminate\Validation\Rule;
 
 class Index extends Component
@@ -19,7 +19,7 @@ class Index extends Component
     // Modal Properties
     public $name = '';
     public $modalSubjectId = '';
-    public $modalSubSubjectId = null; // চ্যাপ্টারের ক্ষেত্রে সাব-সাবজেক্ট থাকতে পারে
+    public $modalChapterId = null; // চ্যাপ্টারের ক্ষেত্রে সাব-সাবজেক্ট থাকতে পারে
     public $editId = null;
 
     protected $listeners = ['deleteTopicConfirmed' => 'delete'];
@@ -37,13 +37,13 @@ class Index extends Component
     // মডালে যখন সাবজেক্ট পরিবর্তন করা হবে, তখন সাব-সাবজেক্ট রিসেট হয়ে যাবে
     public function updatedModalSubjectId()
     {
-        $this->modalSubSubjectId = null;
+        $this->modalChapterId = null;
     }
 
     // ক্রিয়েট বাটনে ক্লিক করলে ফর্ম রিসেট হবে
     public function openModal()
     {
-        $this->reset(['name', 'modalSubjectId', 'modalSubSubjectId', 'editId']);
+        $this->reset(['name', 'modalSubjectId', 'modalChapterId', 'editId']);
         $this->resetValidation();
     }
 
@@ -55,7 +55,7 @@ class Index extends Component
 
         $this->editId = $topic->id;
         $this->modalSubjectId = $topic->subject_id;
-        $this->modalSubSubjectId = $topic->sub_subject_id;
+        $this->modalChapterId = $topic->chapter_id;
         $this->name = $topic->name;
 
         // মডাল ওপেন করার ইভেন্ট
@@ -67,13 +67,13 @@ class Index extends Component
     {
         $this->validate([
             'modalSubjectId' => 'required|exists:subjects,id',
-            'modalSubSubjectId' => 'nullable|exists:sub_subjects,id',
+            'modalChapterId' => 'nullable|exists:chapters,id',
             'name' => [
                 'required',
                 'string',
                 Rule::unique('topics', 'name')
                     ->where('subject_id', $this->modalSubjectId)
-                    ->where('sub_subject_id', $this->modalSubSubjectId)
+                    ->where('chapter_id', $this->modalChapterId)
                     ->ignore($this->editId) // আপডেটের সময় নিজের আইডি ইগনোর করবে
             ],
         ]);
@@ -83,7 +83,7 @@ class Index extends Component
             $topic = Topic::find($this->editId);
             $topic->update([
                 'subject_id' => $this->modalSubjectId,
-                'sub_subject_id' => $this->modalSubSubjectId ?: null, // খালি থাকলে null সেভ হবে
+                'chapter_id' => $this->modalChapterId ?: null, // খালি থাকলে null সেভ হবে
                 'name' => $this->name,
             ]);
             $message = 'Topic updated successfully!';
@@ -91,13 +91,13 @@ class Index extends Component
             // Create
             Topic::create([
                 'subject_id' => $this->modalSubjectId,
-                'sub_subject_id' => $this->modalSubSubjectId ?: null,
+                'chapter_id' => $this->modalChapterId ?: null,
                 'name' => $this->name,
             ]);
             $message = 'Topic created successfully!';
         }
 
-        $this->reset(['name', 'modalSubjectId', 'modalSubSubjectId', 'editId']);
+        $this->reset(['name', 'modalSubjectId', 'modalChapterId', 'editId']);
         $this->dispatch('close-modal');
         $this->dispatch('topicSaved', message: $message);
     }
@@ -115,21 +115,21 @@ class Index extends Component
 
     public function render()
     {
-        $topics = Topic::with('subject', 'subSubject')
+        $topics = Topic::with('subject', 'chapter')
             ->when($this->subjectId, fn($q) => $q->where('subject_id', $this->subjectId))
             ->when($this->search, fn($q) => $q->where('name', 'like', '%'.$this->search.'%'))
             ->orderBy('name')
             ->paginate(10);
 
         // মডালের জন্য ডাইনামিক সাব-সাবজেক্ট লোড করা (যদি সাবজেক্ট সিলেক্ট করা থাকে)
-        $modalSubSubjects = $this->modalSubjectId
-            ? SubSubject::where('subject_id', $this->modalSubjectId)->orderBy('name')->get()
+        $modalChapters = $this->modalSubjectId
+            ? Chapter::where('subject_id', $this->modalSubjectId)->orderBy('name')->get()
             : [];
 
         return view('livewire.admin.topics.index', [
             'topics' => $topics,
             'subjects' => Subject::orderBy('name')->get(),
-            'modalSubSubjects' => $modalSubSubjects, // মডালে পাঠানোর জন্য
+            'modalChapters' => $modalChapters, // মডালে পাঠানোর জন্য
         ])->layout('layouts.admin', ['title' => 'Manage Topics']);
     }
 }

--- a/app/Livewire/Student/Exam.php
+++ b/app/Livewire/Student/Exam.php
@@ -3,18 +3,18 @@
 namespace App\Livewire\Student;
 
 use Livewire\Component;
-use App\Models\{Subject, SubSubject, Topic, Question, ExamResult};
+use App\Models\{Subject, Chapter, Topic, Question, ExamResult};
 
 class Exam extends Component
 {
     public $subjectId = '';
-    public $subSubjectId = '';
+    public $chapterId = '';
     public $topicId = '';
     public $totalQuestions = 20;
     public $duration = 20; // minutes
 
     public $subjects = [];
-    public $subSubjects = [];
+    public $chapters = [];
     public $topics = [];
 
     public $questions = [];
@@ -28,14 +28,14 @@ class Exam extends Component
     public function mount(): void
     {
         $this->subjects = Subject::orderBy('name')->get();
-        $this->loadSubSubjects();
+        $this->loadChapters();
         $this->loadTopics();
     }
 
-    protected function loadSubSubjects(): void
+    protected function loadChapters(): void
     {
-        $this->subSubjects = $this->subjectId
-            ? SubSubject::where('subject_id', $this->subjectId)
+        $this->chapters = $this->subjectId
+            ? Chapter::where('subject_id', $this->subjectId)
                 ->orderBy('name')
                 ->get()
             : collect();
@@ -45,7 +45,7 @@ class Exam extends Component
     {
         $this->topics = Topic::query()
             ->when($this->subjectId, fn ($query) => $query->where('subject_id', $this->subjectId))
-            ->when($this->subSubjectId, fn ($query) => $query->where('sub_subject_id', $this->subSubjectId))
+            ->when($this->chapterId, fn ($query) => $query->where('chapter_id', $this->chapterId))
             ->orderBy('name')
             ->get();
     }
@@ -53,12 +53,12 @@ class Exam extends Component
     public function updatedSubjectId(): void
     {
         $this->topicId = '';
-        $this->subSubjectId = '';
-        $this->loadSubSubjects();
+        $this->chapterId = '';
+        $this->loadChapters();
         $this->loadTopics();
     }
 
-    public function updatedSubSubjectId(): void
+    public function updatedChapterId(): void
     {
         $this->topicId = '';
         $this->loadTopics();
@@ -72,8 +72,8 @@ class Exam extends Component
             $query->where('subject_id', $this->subjectId);
         }
 
-        if ($this->subSubjectId) {
-            $query->where('sub_subject_id', $this->subSubjectId);
+        if ($this->chapterId) {
+            $query->where('chapter_id', $this->chapterId);
         }
 
         if ($this->topicId) {
@@ -149,7 +149,7 @@ class Exam extends Component
     {
         return view('livewire.student.exam')
             ->with([
-                'subSubjects' => $this->subSubjects,
+                'chapters' => $this->chapters,
             ])
             ->layout('layouts.admin', ['title' => 'Exam']);
     }

--- a/app/Livewire/Teacher/CreateQuestionSet.php
+++ b/app/Livewire/Teacher/CreateQuestionSet.php
@@ -3,7 +3,7 @@
 namespace App\Livewire\Teacher;
 
 use App\Models\Question;
-use App\Models\SubSubject;
+use App\Models\Chapter;
 use Livewire\Component;
 use App\Models\Subject;
 use App\Models\Topic;
@@ -35,7 +35,7 @@ class CreateQuestionSet extends Component
     public function updatedSelectedClass($class_id)
     {
         if(!empty($class_id)) {
-            $this->subjects = SubSubject::where('subject_id', $class_id)->get();
+            $this->subjects = Chapter::where('subject_id', $class_id)->get();
         } else {
             $this->subjects = [];
         }
@@ -48,7 +48,7 @@ class CreateQuestionSet extends Component
     public function updatedSelectedSubject($subject_id)
     {
         if(!empty($subject_id)) {
-            $this->topics = Topic::where('sub_subject_id', $subject_id)->get();
+            $this->topics = Topic::where('chapter_id', $subject_id)->get();
         } else {
             $this->topics = [];
         }
@@ -61,7 +61,7 @@ class CreateQuestionSet extends Component
         $this->validate([
             'name' => 'required|string|max:255',
             'selectedClass' => 'required|exists:subjects,id',
-            'selectedSubject' => 'required|exists:sub_subjects,id',
+            'selectedSubject' => 'required|exists:chapters,id',
             'selectedTopics' => 'required|array|min:1',
             'type' => 'required|in:mcq,cq,combine',
             'quantity' => 'required|integer|min:1',
@@ -70,7 +70,7 @@ class CreateQuestionSet extends Component
         // Prepare the generation criteria JSON data
         $criteria = [
             'subject_id' => $this->selectedClass,
-            'sub_subject_id' => $this->selectedSubject,
+            'chapter_id' => $this->selectedSubject,
             'topic_ids' => $this->selectedTopics,
             'type' => $this->type,
             'quantity' => $this->quantity

--- a/app/Livewire/Teacher/GeneratedQuestionSetPage.php
+++ b/app/Livewire/Teacher/GeneratedQuestionSetPage.php
@@ -10,7 +10,7 @@ class GeneratedQuestionSetPage extends Component
     public QuestionSet $questionSet;
 
     public $subject;
-    public $subSubject;
+    public $chapter;
     public $topics;
 
     // URL থেকে পাওয়া আইডি দিয়ে কম্পোনেন্ট মাউন্ট হবে
@@ -19,7 +19,7 @@ class GeneratedQuestionSetPage extends Component
         // আইডি দিয়ে QuestionSet এবং এর সাথে সম্পর্কিত Class খুঁজে বের করুন
         $this->questionSet = QuestionSet::with('user')->findOrFail($qset);
         $this->subject = $this->questionSet->getRelatedSubject();
-        $this->subSubject = $this->questionSet->getRelatedSubSubject();
+        $this->chapter = $this->questionSet->getRelatedChapter();
         $this->topics = $this->questionSet->getRelatedTopics();
     }
 

--- a/app/Livewire/Teacher/QuestionGenerator.php
+++ b/app/Livewire/Teacher/QuestionGenerator.php
@@ -4,14 +4,14 @@ namespace App\Livewire\Teacher;
 
 use Livewire\Component;
 use Illuminate\Database\Eloquent\Builder;
-use App\Models\{Subject, SubSubject, Topic, Question};
+use App\Models\{Subject, Chapter, Topic, Question};
 use App\Support\Fonts;
 
 class QuestionGenerator extends Component
 {
     public string $examName = '';
     public ?int $subjectId = null;
-    public ?int $subSubjectId = null;
+    public ?int $chapterId = null;
     public ?int $topicId = null;
     public string $questionType = 'mcq';
     public int $questionCount = 5;
@@ -34,7 +34,7 @@ class QuestionGenerator extends Component
         'attachOmrSheet' => false,
         'markImportant' => false,
         'showQuestionInfo' => true,
-        'showSubSubject' => true,
+        'showChapter' => true,
         'showTopic' => true,
         'showSetCode' => true,
         'showStudentInfo' => false,
@@ -51,7 +51,7 @@ class QuestionGenerator extends Component
     public string $paperSize = 'A4';
 
     /** @var array<int, array{id:int,name:string}> */
-    public array $subSubjects = [];
+    public array $chapters = [];
 
     /** @var array<int, array{id:int,name:string}> */
     public array $topics = [];
@@ -75,7 +75,7 @@ class QuestionGenerator extends Component
     protected array $rules = [
         'examName' => 'required|string|min:3',
         'subjectId' => 'required|exists:subjects,id',
-        'subSubjectId' => 'nullable|exists:sub_subjects,id',
+        'chapterId' => 'nullable|exists:chapters,id',
         'topicId' => 'nullable|exists:topics,id',
         'questionType' => 'required|string|in:mcq,creative,composite',
         'questionCount' => 'required|integer|min:1|max:50',
@@ -92,7 +92,7 @@ class QuestionGenerator extends Component
     protected array $validationAttributes = [
         'examName' => 'পরীক্ষার নাম',
         'subjectId' => 'বিষয়',
-        'subSubjectId' => 'সাব-বিষয়',
+        'chapterId' => 'সাব-বিষয়',
         'topicId' => 'অধ্যায়',
         'questionType' => 'প্রশ্নের ধরন',
         'questionCount' => 'প্রশ্নের সংখ্যা',
@@ -116,19 +116,19 @@ class QuestionGenerator extends Component
     public function updatedSubjectId($value): void
     {
         $this->topicId = null;
-        $this->subSubjectId = null;
-        $this->subSubjects = $value
-            ? SubSubject::query()
+        $this->chapterId = null;
+        $this->chapters = $value
+            ? Chapter::query()
                 ->where('subject_id', $value)
                 ->orderBy('name')
                 ->get(['id', 'name'])
-                ->map(fn (SubSubject $subSubject) => ['id' => $subSubject->id, 'name' => $subSubject->name])
+                ->map(fn (Chapter $chapter) => ['id' => $chapter->id, 'name' => $chapter->name])
                 ->all()
             : [];
 
         $this->topics = [];
 
-        if ($value && empty($this->subSubjects)) {
+        if ($value && empty($this->chapters)) {
             $this->topics = Topic::query()
                 ->where('subject_id', $value)
                 ->orderBy('name')
@@ -138,7 +138,7 @@ class QuestionGenerator extends Component
         }
     }
 
-    public function updatedSubSubjectId($value): void
+    public function updatedChapterId($value): void
     {
         $this->topicId = null;
 
@@ -148,7 +148,7 @@ class QuestionGenerator extends Component
         }
 
         $this->topics = Topic::query()
-            ->where('sub_subject_id', $value)
+            ->where('chapter_id', $value)
             ->orderBy('name')
             ->get(['id', 'name'])
             ->map(fn (Topic $topic) => ['id' => $topic->id, 'name' => $topic->name])
@@ -161,7 +161,7 @@ class QuestionGenerator extends Component
             return;
         }
 
-        if ($this->subSubjectId && ! Topic::where('id', $value)->where('sub_subject_id', $this->subSubjectId)->exists()) {
+        if ($this->chapterId && ! Topic::where('id', $value)->where('chapter_id', $this->chapterId)->exists()) {
             $this->addError('topicId', __('নির্বাচিত অধ্যায় এই সাব-বিষয়ের অন্তর্ভুক্ত নয়।'));
             $this->topicId = null;
             return;
@@ -180,11 +180,11 @@ class QuestionGenerator extends Component
         $this->showPreview = false;
 
         $baseQuery = Question::query()
-            ->with(['topic.subSubject', 'subject', 'tags'])
+            ->with(['topic.chapter', 'subject', 'tags'])
             ->where('subject_id', $this->subjectId);
 
-        if ($this->subSubjectId) {
-            $baseQuery->where('sub_subject_id', $this->subSubjectId);
+        if ($this->chapterId) {
+            $baseQuery->where('chapter_id', $this->chapterId);
         }
 
         if ($this->topicId) {
@@ -260,7 +260,7 @@ class QuestionGenerator extends Component
         ]);
 
         $relations = [
-            'topic.subSubject',
+            'topic.chapter',
             'subject',
         ];
 
@@ -278,15 +278,15 @@ class QuestionGenerator extends Component
             return;
         }
 
-        $hasSubSubjects = ! empty($this->subSubjects);
+        $hasChapters = ! empty($this->chapters);
 
         $this->questionPaperSummary = [
             'exam_name' => $this->examName,
             'program_name' => $this->programName ?: $this->examName,
             'subject' => optional($selectedQuestions->first()->subject)->name,
-            'sub_subject' => $this->subSubjectId
-                ? optional($selectedQuestions->first()->topic?->subSubject)->name
-                : ($hasSubSubjects ? __('বহু সাব-বিষয়') : __('সাব-বিষয় প্রযোজ্য নয়')),
+            'chapter' => $this->chapterId
+                ? optional($selectedQuestions->first()->topic?->chapter)->name
+                : ($hasChapters ? __('বহু সাব-বিষয়') : __('সাব-বিষয় প্রযোজ্য নয়')),
             'topic' => $this->topicId ? optional($selectedQuestions->first()->topic)->name : __('বহু অধ্যায়'),
             'type' => $this->questionTypeLabel($this->questionType),
             'type_key' => $this->questionType,
@@ -390,7 +390,7 @@ class QuestionGenerator extends Component
         return view('livewire.teacher.question-generator-copy', [
             'subjects' => Subject::orderBy('name')->get(['id', 'name']),
             'typeOptions' => $this->questionTypeOptions(),
-            'subSubjects' => $this->subSubjects,
+            'chapters' => $this->chapters,
             'topics' => $this->topics,
             'sortOptions' => $this->sortOptions(),
             'fontOptions' => $this->fontFamilyOptions(),

--- a/app/Livewire/Teacher/QuestionPaper.php
+++ b/app/Livewire/Teacher/QuestionPaper.php
@@ -15,7 +15,7 @@ class QuestionPaper extends Component
     // Header Info
     public $instituteName;
     public $subject;
-    public $subSubject;
+    public $chapter;
     public $topics;
 
     // Formatting & Layout Properties
@@ -37,7 +37,7 @@ class QuestionPaper extends Component
         'attachOmrSheet' => false,
         'markImportant' => false,
         'showQuestionInfo' => true,
-        'showSubSubject' => true,
+        'showChapter' => true,
         'showTopic' => false,
         'showSetCode' => true,
         'showStudentInfo' => false,
@@ -61,7 +61,7 @@ class QuestionPaper extends Component
         $this->questions = $this->questionSet->questions;
 
         $this->subject = $this->questionSet->getRelatedSubject();
-        $this->subSubject = $this->questionSet->getRelatedSubSubject();
+        $this->chapter = $this->questionSet->getRelatedChapter();
         $this->topics = $this->questionSet->getRelatedTopics();
         $this->instituteName = $this->questionSet->user->institution_name ?? 'প্রতিষ্ঠানের নাম';
 

--- a/app/Livewire/Teacher/ViewQuestions.php
+++ b/app/Livewire/Teacher/ViewQuestions.php
@@ -37,7 +37,7 @@ class ViewQuestions extends Component
         $type = $criteria['type'] ?? 'mcq';
         $quantity = $criteria['quantity'] ?? 100;
         $subjectId = $criteria['subject_id'] ?? null;
-        $subSubjectId = $criteria['sub_subject_id'] ?? null;
+        $chapterId = $criteria['chapter_id'] ?? null;
         $topicId = $criteria['topic_id'] ?? null;
 
         // ৪. শর্ত অনুযায়ী প্রশ্ন খুঁজুন
@@ -59,7 +59,7 @@ class ViewQuestions extends Component
                 }
             })
             ->when($subjectId, fn ($q) => $q->where('subject_id', $subjectId))
-            ->when($subSubjectId, fn ($q) => $q->where('sub_subject_id', $subSubjectId))
+            ->when($chapterId, fn ($q) => $q->where('chapter_id', $chapterId))
             ->when($topicId, fn ($q) => $q->where('topic_id', $topicId))
             ->inRandomOrder()
             ->limit($quantity)

--- a/app/Models/Chapter.php
+++ b/app/Models/Chapter.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
-class SubSubject extends Model
+class Chapter extends Model
 {
     protected $fillable = ['subject_id', 'name'];
 

--- a/app/Models/Question.php
+++ b/app/Models/Question.php
@@ -15,7 +15,7 @@ class Question extends Model
 
     protected $fillable = [
         'subject_id',
-        'sub_subject_id',
+        'chapter_id',
         'topic_id',
         'title',
         'description',
@@ -58,9 +58,9 @@ class Question extends Model
         return $this->belongsTo(Subject::class);
     }
 
-    public function subSubject(): BelongsTo
+    public function chapter(): BelongsTo
     {
-        return $this->belongsTo(SubSubject::class);
+        return $this->belongsTo(Chapter::class);
     }
 
     public function topic(): BelongsTo

--- a/app/Models/QuestionSet.php
+++ b/app/Models/QuestionSet.php
@@ -35,10 +35,10 @@ class QuestionSet extends Model
         return $subjectId ? Subject::find($subjectId) : null;
     }
 
-    public function getRelatedSubSubject()
+    public function getRelatedChapter()
     {
-        $subSubjectId = $this->generation_criteria['sub_subject_id'] ?? null;
-        return $subSubjectId ? SubSubject::find($subSubjectId) : null;
+        $chapterId = $this->generation_criteria['chapter_id'] ?? null;
+        return $chapterId ? Chapter::find($chapterId) : null;
     }
 
 
@@ -57,9 +57,9 @@ class QuestionSet extends Model
         return $this->belongsTo(Subject::class);
     }
 
-    public function subSubject()
+    public function chapter()
     {
-        return $this->belongsTo(SubSubject::class);
+        return $this->belongsTo(Chapter::class);
     }
     public function topics()
     {
@@ -78,7 +78,7 @@ class QuestionSet extends Model
 
         // ২. শর্তগুলো থেকে প্রয়োজনীয় আইডি এবং তথ্য বের করুন
         $subjectId = $criteria['subject_id'] ?? null;
-        $subSubjectId = $criteria['sub_subject_id'] ?? null; // নতুন শর্ত
+        $chapterId = $criteria['chapter_id'] ?? null; // নতুন শর্ত
         $topicIds = $criteria['topic_ids'] ?? [];
         $type = $criteria['type'] ?? 'mcq';
         $difficulty = $criteria['difficulty'] ?? null;
@@ -94,18 +94,18 @@ class QuestionSet extends Model
             ->whereIn('topic_id', $topicIds);
 
 
-        // 'topic' রিলেশনশিপ ব্যবহার করে subject এবং sub_subject অনুযায়ী ফিল্টার করুন
+        // 'topic' রিলেশনশিপ ব্যবহার করে subject এবং chapter অনুযায়ী ফিল্টার করুন
         if ($subjectId) {
-            $query->whereHas('topic', function ($topicQuery) use ($subjectId, $subSubjectId) {
+            $query->whereHas('topic', function ($topicQuery) use ($subjectId, $chapterId) {
 
                 // Topic-এর সাথে সম্পর্কিত Subject-এর উপর শর্ত
                 $topicQuery->where('subject_id', $subjectId);
 
-                // যদি sub_subject_id থাকে, তাহলে Subject-এর সাথে সম্পর্কিত SubSubject-এর উপর শর্ত
-                if ($subSubjectId) {
-                    $topicQuery->whereHas('subject', function ($subjectQuery) use ($subSubjectId) {
-                        // আপনার Subject ও SubSubject মডেলের মধ্যে সম্পর্ক অনুযায়ী এখানে কুয়েরি করতে হবে
-                        // উদাহরণস্বরূপ: $subjectQuery->where('sub_subject_id', $subSubjectId);
+                // যদি chapter_id থাকে, তাহলে Subject-এর সাথে সম্পর্কিত Chapter-এর উপর শর্ত
+                if ($chapterId) {
+                    $topicQuery->whereHas('subject', function ($subjectQuery) use ($chapterId) {
+                        // আপনার Subject ও Chapter মডেলের মধ্যে সম্পর্ক অনুযায়ী এখানে কুয়েরি করতে হবে
+                        // উদাহরণস্বরূপ: $subjectQuery->where('chapter_id', $chapterId);
                     });
                 }
             });

--- a/app/Models/Subject.php
+++ b/app/Models/Subject.php
@@ -14,9 +14,9 @@ class Subject extends Model
         return $this->hasMany(Topic::class);
     }
 
-    public function subSubjects(): HasMany
+    public function chapters(): HasMany
     {
-        return $this->hasMany(SubSubject::class);
+        return $this->hasMany(Chapter::class);
     }
 
     public function questions(): HasMany

--- a/app/Models/Topic.php
+++ b/app/Models/Topic.php
@@ -8,16 +8,16 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Topic extends Model
 {
-    protected $fillable = ['subject_id', 'sub_subject_id', 'name'];
+    protected $fillable = ['subject_id', 'chapter_id', 'name'];
 
     public function subject(): BelongsTo
     {
         return $this->belongsTo(Subject::class);
     }
 
-    public function subSubject(): BelongsTo
+    public function chapter(): BelongsTo
     {
-        return $this->belongsTo(SubSubject::class);
+        return $this->belongsTo(Chapter::class);
     }
 
     public function questions(): HasMany

--- a/database/migrations/2025_08_14_231809_create_chapters_table.php
+++ b/database/migrations/2025_08_14_231809_create_chapters_table.php
@@ -8,7 +8,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('sub_subjects', function (Blueprint $table) {
+        Schema::create('chapters', function (Blueprint $table) {
             $table->id();
             $table->foreignId('subject_id')->constrained()->cascadeOnDelete();
             $table->string('name');
@@ -19,6 +19,6 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::dropIfExists('sub_subjects');
+        Schema::dropIfExists('chapters');
     }
 };

--- a/database/migrations/2025_08_14_231810_add_chapter_id_to_topics_table.php
+++ b/database/migrations/2025_08_14_231810_add_chapter_id_to_topics_table.php
@@ -9,15 +9,15 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('topics', function (Blueprint $table) {
-            $table->foreignId('sub_subject_id')->nullable()->constrained('sub_subjects')->cascadeOnDelete();
+            $table->foreignId('chapter_id')->nullable()->constrained('chapters')->cascadeOnDelete();
         });
     }
 
     public function down(): void
     {
         Schema::table('topics', function (Blueprint $table) {
-            $table->dropForeign(['sub_subject_id']);
-            $table->dropColumn('sub_subject_id');
+            $table->dropForeign(['chapter_id']);
+            $table->dropColumn('chapter_id');
         });
     }
 };

--- a/database/migrations/2025_08_14_231811_add_chapter_id_to_questions_table.php
+++ b/database/migrations/2025_08_14_231811_add_chapter_id_to_questions_table.php
@@ -9,15 +9,15 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('questions', function (Blueprint $table) {
-            $table->foreignId('sub_subject_id')->nullable()->constrained('sub_subjects')->cascadeOnDelete();
+            $table->foreignId('chapter_id')->nullable()->constrained('chapters')->cascadeOnDelete();
         });
     }
 
     public function down(): void
     {
         Schema::table('questions', function (Blueprint $table) {
-            $table->dropForeign(['sub_subject_id']);
-            $table->dropColumn('sub_subject_id');
+            $table->dropForeign(['chapter_id']);
+            $table->dropColumn('chapter_id');
         });
     }
 };

--- a/resources/views/livewire/admin/chapters/index.blade.php
+++ b/resources/views/livewire/admin/chapters/index.blade.php
@@ -7,7 +7,7 @@
         <div class="flex flex-col sm:flex-row gap-4 flex-1">
             <input type="text"
                    wire:model.live.debounce.300ms="search"
-                   placeholder="Search sub-subjects..."
+                   placeholder="Search chapters..."
                    class="flex-1 px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
 
             <select wire:model.live="subjectId"
@@ -28,7 +28,7 @@
         <button @click="showModal = true; $wire.openModal();"
                 class="inline-flex items-center justify-center gap-2 px-5 py-2.5 bg-indigo-600 text-white font-medium text-sm rounded-lg shadow-sm hover:bg-indigo-700 transition-all focus:outline-none shrink-0">
             <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 448 512" height="1.1em" width="1.1em" xmlns="http://www.w3.org/2000/svg"><path d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"></path></svg>
-            New Sub Subject
+            New Chapter
         </button>
     </div>
 
@@ -37,30 +37,30 @@
             <thead>
             <tr class="bg-gray-50/80 dark:bg-gray-700/50 border-b border-gray-200 dark:border-gray-600 text-gray-500 dark:text-gray-300">
                 <th class="px-6 py-4 text-left font-semibold uppercase tracking-wider text-xs w-24">#ID</th>
-                <th class="px-6 py-4 text-left font-semibold uppercase tracking-wider text-xs">Sub Subject Name</th>
+                <th class="px-6 py-4 text-left font-semibold uppercase tracking-wider text-xs">Chapter Name</th>
                 <th class="px-6 py-4 text-left font-semibold uppercase tracking-wider text-xs">Parent Subject</th>
                 <th class="px-6 py-4 text-right font-semibold uppercase tracking-wider text-xs w-32">Actions</th>
             </tr>
             </thead>
             <tbody class="divide-y divide-gray-100 dark:divide-gray-700 bg-white dark:bg-gray-800">
-            @forelse($subSubjects as $subSubject)
+            @forelse($chapters as $chapter)
                 <tr class="hover:bg-indigo-50/50 dark:hover:bg-gray-700/50 transition-colors group">
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200">
-                            #{{ $subSubject->id }}
+                            #{{ $chapter->id }}
                         </span>
                     </td>
                     <td class="px-6 py-4 font-medium text-gray-900 dark:text-gray-100">
-                        {{ $subSubject->name }}
+                        {{ $chapter->name }}
                     </td>
                     <td class="px-6 py-4">
                         <span class="text-sm font-semibold text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-900/30 px-3 py-1 rounded-md border border-indigo-100 dark:border-indigo-800">
-                            {{ $subSubject->subject->name }}
+                            {{ $chapter->subject->name }}
                         </span>
                     </td>
                     <td class="px-6 py-4 text-right space-x-1">
 
-                        <button type="button" wire:click="edit({{ $subSubject->id }})"
+                        <button type="button" wire:click="edit({{ $chapter->id }})"
                                 class="inline-flex items-center justify-center w-8 h-8 rounded-md text-indigo-500 hover:text-white hover:bg-indigo-500 transition-colors border border-indigo-100 hover:border-transparent dark:border-gray-600 dark:hover:bg-indigo-600" title="Edit">
                             <svg stroke="currentColor" fill="none" stroke-width="2" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" height="1em" width="1em" xmlns="http://www.w3.org/2000/svg"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg>
                         </button>
@@ -78,12 +78,12 @@
                                             confirmButtonText: 'Yes, delete it!'
                                         }).then((result) => {
                                             if (result.isConfirmed) {
-                                                $wire.delete({{ $subSubject->id }});
+                                                $wire.delete({{ $chapter->id }});
                                             }
                                         });
                                     } else {
-                                        if(confirm('Are you sure you want to delete this sub-subject?')) {
-                                            $wire.delete({{ $subSubject->id }});
+                                        if(confirm('Are you sure you want to delete this chapter?')) {
+                                            $wire.delete({{ $chapter->id }});
                                         }
                                     }
                                 "
@@ -97,7 +97,7 @@
                     <td colspan="4" class="px-6 py-12 text-center">
                         <div class="flex flex-col items-center justify-center text-gray-400 dark:text-gray-500">
                             <svg stroke="currentColor" fill="none" stroke-width="2" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" class="mb-3 text-gray-300 dark:text-gray-600" height="3em" width="3em" xmlns="http://www.w3.org/2000/svg"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
-                            <p class="text-lg font-medium">No sub-subjects found</p>
+                            <p class="text-lg font-medium">No chapters found</p>
                             <p class="text-sm mt-1">Try adjusting your search or filter to find what you're looking for.</p>
                         </div>
                     </td>
@@ -107,9 +107,9 @@
         </table>
     </div>
 
-    @if($subSubjects->hasPages())
+    @if($chapters->hasPages())
         <div class="p-4 border-t border-gray-100 dark:border-gray-700 bg-gray-50/30 dark:bg-gray-800/30">
-            {{ $subSubjects->links() }}
+            {{ $chapters->links() }}
         </div>
     @endif
 
@@ -135,7 +135,7 @@
 
                 <div class="bg-gray-50 dark:bg-gray-700/50 px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
                     <h3 class="text-lg leading-6 font-bold text-gray-900 dark:text-white" id="modal-title">
-                        {{ $editId ? 'Edit Sub Subject' : 'Create New Sub Subject' }}
+                        {{ $editId ? 'Edit Chapter' : 'Create New Chapter' }}
                     </h3>
                     <button @click="showModal = false" class="text-gray-400 hover:text-gray-500 focus:outline-none">
                         <span class="sr-only">Close</span>
@@ -156,7 +156,7 @@
                         </div>
 
                         <div>
-                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Sub Subject Name <span class="text-red-500">*</span></label>
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Chapter Name <span class="text-red-500">*</span></label>
                             <input type="text" wire:model="name" placeholder="e.g. Physics 1st Paper" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200 dark:bg-gray-700 dark:text-white dark:border-gray-600">
                             @error('name') <span class="text-xs text-red-500 mt-1 block">{{ $message }}</span> @enderror
                         </div>
@@ -169,7 +169,7 @@
                         </button>
                         <button type="submit" class="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 flex items-center gap-2">
                             <svg wire:loading wire:target="save" class="animate-spin h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
-                            <span wire:loading.remove wire:target="save">{{ $editId ? 'Update Sub Subject' : 'Save Sub Subject' }}</span>
+                            <span wire:loading.remove wire:target="save">{{ $editId ? 'Update Chapter' : 'Save Chapter' }}</span>
                             <span wire:loading wire:target="save">{{ $editId ? 'Updating...' : 'Saving...' }}</span>
                         </button>
                     </div>
@@ -201,18 +201,18 @@
 
                 <div class="bg-emerald-50 dark:bg-emerald-900/30 px-6 py-4 border-b border-emerald-100 dark:border-gray-700 flex justify-between items-center">
                     <h3 class="text-lg leading-6 font-bold text-emerald-800 dark:text-emerald-400" id="modal-title">
-                        Clone Sub Subjects
+                        Clone Chapters
                     </h3>
                     <button @click="$wire.showCloneModal = false" class="text-gray-400 hover:text-gray-500 focus:outline-none">
                         <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
                     </button>
                 </div>
 
-                <form wire:submit.prevent="cloneSubSubjects">
+                <form wire:submit.prevent="cloneChapters">
                     <div class="px-6 py-6 space-y-5">
 
                         <div class="p-3 bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 text-sm rounded-md border border-blue-100 dark:border-blue-800">
-                            <strong>Tips:</strong> Copy all sub-subjects from one subject to another instantly! Duplicate names will be skipped.
+                            <strong>Tips:</strong> Copy all chapters from one subject to another instantly! Duplicate names will be skipped.
                         </div>
 
                         <div>
@@ -244,9 +244,9 @@
                             Cancel
                         </button>
                         <button type="submit" class="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-emerald-600 hover:bg-emerald-700 flex items-center gap-2">
-                            <svg wire:loading wire:target="cloneSubSubjects" class="animate-spin h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
-                            <span wire:loading.remove wire:target="cloneSubSubjects">Copy Sub-Subjects</span>
-                            <span wire:loading wire:target="cloneSubSubjects">Copying...</span>
+                            <svg wire:loading wire:target="cloneChapters" class="animate-spin h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
+                            <span wire:loading.remove wire:target="cloneChapters">Copy Chapters</span>
+                            <span wire:loading wire:target="cloneChapters">Copying...</span>
                         </button>
                     </div>
                 </form>
@@ -272,11 +272,11 @@
         }
 
         // ক্রিয়েট বা আপডেট হওয়ার পর সাকসেস মেসেজ শো করা
-        window.addEventListener('subSubjectSaved', e => {
+        window.addEventListener('chapterSaved', e => {
             showToast(e.detail.message);
         });
 
-        window.addEventListener('subSubjectDeleted', e => {
+        window.addEventListener('chapterDeleted', e => {
             showToast(e.detail.message || 'Sub subject has been deleted successfully.');
         });
     </script>

--- a/resources/views/livewire/admin/partials/sidebar.blade.php
+++ b/resources/views/livewire/admin/partials/sidebar.blade.php
@@ -11,7 +11,7 @@
     $questionsActive = request()->is('admin/questions*')
         || request()->is('admin/exam-categories')
         || request()->is('admin/subjects*')
-        || request()->is('admin/sub-subjects*')
+        || request()->is('admin/chapters*')
         || request()->is('admin/topics*')
         || request()->is('admin/tags*');
 
@@ -87,9 +87,9 @@
                        class="{{ $submenuLinkClasses }} {{ request()->is('admin/subjects*') ? $submenuActiveClasses : '' }}">
                         <span class="sidebar-text">Subjects</span>
                     </a>
-                    <a wire:navigate href="{{ route('admin.sub-subjects.index') }}"
-                       class="{{ $submenuLinkClasses }} {{ request()->is('admin/sub-subjects*') ? $submenuActiveClasses : '' }}">
-                        <span class="sidebar-text">Sub Subjects</span>
+                    <a wire:navigate href="{{ route('admin.chapters.index') }}"
+                       class="{{ $submenuLinkClasses }} {{ request()->is('admin/chapters*') ? $submenuActiveClasses : '' }}">
+                        <span class="sidebar-text">Chapters</span>
                     </a>
                     <a wire:navigate href="{{ route('admin.topics.index') }}"
                        class="{{ $submenuLinkClasses }} {{ request()->is('admin/topics*') ? $submenuActiveClasses : '' }}">

--- a/resources/views/livewire/admin/questions/_form.blade.php
+++ b/resources/views/livewire/admin/questions/_form.blade.php
@@ -34,10 +34,10 @@
                 </div>
 
                 <div wire:ignore wire:key="subsubject-select-{{ $question->id ?? 'create' }}">
-                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Sub-Subject</label>
-                    <select id="sub_subject" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-700 dark:text-gray-200">
-                        <option value="">-- Select Sub-Subject --</option>
-                        @foreach($subSubjects as $ss) <option value="{{ $ss->id }}" @selected($ss->id == $sub_subject_id)>{{ $ss->name }}</option> @endforeach
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Chapter</label>
+                    <select id="chapter" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-700 dark:text-gray-200">
+                        <option value="">-- Select Chapter --</option>
+                        @foreach($chapters as $ss) <option value="{{ $ss->id }}" @selected($ss->id == $chapter_id)>{{ $ss->name }}</option> @endforeach
                     </select>
                 </div>
 
@@ -304,7 +304,7 @@
 
     <script>
         window.tsSubject = window.tsSubject || null;
-        window.tsSubSubject = window.tsSubSubject || null;
+        window.tsChapter = window.tsChapter || null;
         window.tsTopic = window.tsTopic || null;
         window.tsTags = window.tsTags || null;
         window.tsExamCategories = window.tsExamCategories || null;
@@ -404,9 +404,9 @@
             const subjectEl = document.getElementById('subject');
             if (subjectEl) window.tsSubject = new TomSelect(subjectEl, { onChange: (v) => @this.set('subject_id', v) });
 
-            if (window.tsSubSubject) { window.tsSubSubject.destroy(); window.tsSubSubject = null; }
-            const subSubjectEl = document.getElementById('sub_subject');
-            if (subSubjectEl) window.tsSubSubject = new TomSelect(subSubjectEl, { onChange: (v) => @this.set('sub_subject_id', v) });
+            if (window.tsChapter) { window.tsChapter.destroy(); window.tsChapter = null; }
+            const chapterEl = document.getElementById('chapter');
+            if (chapterEl) window.tsChapter = new TomSelect(chapterEl, { onChange: (v) => @this.set('chapter_id', v) });
 
             if (window.tsTopic) { window.tsTopic.destroy(); window.tsTopic = null; }
             const topicEl = document.getElementById('topic');
@@ -429,13 +429,13 @@
 
         if (!window.hasRegisteredQuestionEvents) {
 
-            window.addEventListener('subSubjectsUpdated', e => {
-                if (window.tsSubSubject) {
-                    window.tsSubSubject.clear(true);
-                    window.tsSubSubject.clearOptions();
-                    window.tsSubSubject.addOption({value: '', text: '-- Select Sub-Subject --'});
-                    window.tsSubSubject.addOptions(e.detail.subSubjects);
-                    window.tsSubSubject.refreshOptions(false);
+            window.addEventListener('chaptersUpdated', e => {
+                if (window.tsChapter) {
+                    window.tsChapter.clear(true);
+                    window.tsChapter.clearOptions();
+                    window.tsChapter.addOption({value: '', text: '-- Select Chapter --'});
+                    window.tsChapter.addOptions(e.detail.chapters);
+                    window.tsChapter.refreshOptions(false);
                 }
             });
 
@@ -451,7 +451,7 @@
 
             window.addEventListener('reset-selects', () => {
                 window.tsSubject?.clear(true);
-                window.tsSubSubject?.clear(true);
+                window.tsChapter?.clear(true);
                 window.tsTopic?.clear(true);
                 window.tsExamCategories?.clear(true);
             });
@@ -468,7 +468,7 @@
                 }
 
                 if (window.tsSubject) { window.tsSubject.destroy(); window.tsSubject = null; }
-                if (window.tsSubSubject) { window.tsSubSubject.destroy(); window.tsSubSubject = null; }
+                if (window.tsChapter) { window.tsChapter.destroy(); window.tsChapter = null; }
                 if (window.tsTopic) { window.tsTopic.destroy(); window.tsTopic = null; }
                 if (window.tsTags) { window.tsTags.destroy(); window.tsTags = null; }
                 if (window.tsExamCategories) { window.tsExamCategories.destroy(); window.tsExamCategories = null; }

--- a/resources/views/livewire/admin/questions/question-form.blade.php
+++ b/resources/views/livewire/admin/questions/question-form.blade.php
@@ -11,12 +11,12 @@
             </select>
         </div>
 
-        {{-- Sub-Subject (Optional) --}}
+        {{-- Chapter (Optional) --}}
         <div>
-            <label>Sub-Subject (Optional)</label>
-            <select wire:model="sub_subject_id" class="border p-2 rounded w-full">
+            <label>Chapter (Optional)</label>
+            <select wire:model="chapter_id" class="border p-2 rounded w-full">
                 <option value="">-- Select --</option>
-                @foreach($subSubjects as $ss)
+                @foreach($chapters as $ss)
                     <option value="{{ $ss->id }}">{{ $ss->name }}</option>
                 @endforeach
             </select>
@@ -25,7 +25,7 @@
         {{-- Topic (Optional) --}}
         <div>
             <label>Topic (Optional)</label>
-            <select wire:model="topic_id" class="border p-2 rounded w-full" {{ $sub_subject_id ? '' : 'disabled' }}>
+            <select wire:model="topic_id" class="border p-2 rounded w-full" {{ $chapter_id ? '' : 'disabled' }}>
                 <option value="">-- Select --</option>
                 @foreach($topics as $c)
                     <option value="{{ $c->id }}">{{ $c->name }}</option>

--- a/resources/views/livewire/admin/topics/index.blade.php
+++ b/resources/views/livewire/admin/topics/index.blade.php
@@ -39,7 +39,7 @@
                 <th class="px-6 py-4 text-left font-semibold uppercase tracking-wider text-xs w-24">#ID</th>
                 <th class="px-6 py-4 text-left font-semibold uppercase tracking-wider text-xs">Topic Name</th>
                 <th class="px-6 py-4 text-left font-semibold uppercase tracking-wider text-xs">Subject</th>
-                <th class="px-6 py-4 text-left font-semibold uppercase tracking-wider text-xs">Sub Subject</th>
+                <th class="px-6 py-4 text-left font-semibold uppercase tracking-wider text-xs">Chapter</th>
                 <th class="px-6 py-4 text-right font-semibold uppercase tracking-wider text-xs w-32">Actions</th>
             </tr>
             </thead>
@@ -60,9 +60,9 @@
                         </span>
                     </td>
                     <td class="px-6 py-4">
-                        @if($topic->subSubject)
+                        @if($topic->chapter)
                             <span class="text-sm font-semibold text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/30 px-3 py-1 rounded-md border border-emerald-100 dark:border-emerald-800">
-                                {{ $topic->subSubject->name }}
+                                {{ $topic->chapter->name }}
                             </span>
                         @else
                             <span class="text-xs text-gray-400 dark:text-gray-500 italic">N/A</span>
@@ -163,17 +163,17 @@
                             @error('modalSubjectId') <span class="text-xs text-red-500 mt-1 block">{{ $message }}</span> @enderror
                         </div>
 
-                        <div wire:key="sub-subject-group-{{ $modalSubjectId ?? 'empty' }}">
-                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Select Sub Subject <span class="text-xs font-normal text-gray-400">(Optional)</span></label>
-                            <select wire:model="modalSubSubjectId"
+                        <div wire:key="chapter-group-{{ $modalSubjectId ?? 'empty' }}">
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Select Chapter <span class="text-xs font-normal text-gray-400">(Optional)</span></label>
+                            <select wire:model="modalChapterId"
                                     class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring focus:ring-indigo-200 dark:bg-gray-700 dark:text-white dark:border-gray-600 disabled:opacity-50"
                                     @if(!$modalSubjectId) disabled @endif>
                                 <option value="">-- None --</option>
-                                @foreach($modalSubSubjects as $ss)
+                                @foreach($modalChapters as $ss)
                                     <option value="{{ $ss->id }}">{{ $ss->name }}</option>
                                 @endforeach
                             </select>
-                            @error('modalSubSubjectId') <span class="text-xs text-red-500 mt-1 block">{{ $message }}</span> @enderror
+                            @error('modalChapterId') <span class="text-xs text-red-500 mt-1 block">{{ $message }}</span> @enderror
                         </div>
 
                         <div>

--- a/resources/views/livewire/student/exam.blade.php
+++ b/resources/views/livewire/student/exam.blade.php
@@ -8,10 +8,10 @@
                 @endforeach
             </select>
 
-            <select wire:model="subSubjectId" class="w-full border rounded px-3 py-2">
+            <select wire:model="chapterId" class="w-full border rounded px-3 py-2">
                 <option value="">সাব-বিষয় সিলেক্ট করো</option>
-                @foreach($subSubjects as $subSubject)
-                    <option value="{{ $subSubject->id }}">{{ $subSubject->name }}</option>
+                @foreach($chapters as $chapter)
+                    <option value="{{ $chapter->id }}">{{ $chapter->name }}</option>
                 @endforeach
             </select>
 

--- a/resources/views/livewire/teacher/question-generator-copy.blade.php
+++ b/resources/views/livewire/teacher/question-generator-copy.blade.php
@@ -49,16 +49,16 @@
                 </div>
 
                 <div>
-                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1" for="subSubject">সাব-বিষয়</label>
-                    <select id="subSubject" wire:model="subSubjectId"
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1" for="chapter">সাব-বিষয়</label>
+                    <select id="chapter" wire:model="chapterId"
                             class="w-full rounded border-gray-300 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100 focus:border-indigo-500 focus:ring-indigo-500"
-                            @disabled(empty($subSubjects))>
+                            @disabled(empty($chapters))>
                         <option value="">সাব-বিষয় নির্বাচন করুন</option>
-                        @foreach($subSubjects as $subSubject)
-                            <option value="{{ $subSubject['id'] }}">{{ $subSubject['name'] }}</option>
+                        @foreach($chapters as $chapter)
+                            <option value="{{ $chapter['id'] }}">{{ $chapter['name'] }}</option>
                         @endforeach
                     </select>
-                    @error('subSubjectId')
+                    @error('chapterId')
                         <p class="text-sm text-red-500 mt-1">{{ $message }}</p>
                     @enderror
                 </div>
@@ -314,8 +314,8 @@
                                     <h1 class="text-xl font-bold text-center">{{ $summary['program_name'] ?? $summary['exam_name'] }}</h1>
                                     <div class="relative">
                                         <p contenteditable="true" class="text-center text-lg editable-effect">{{ $summary['subject'] }}</p>
-                                        @if($previewOptions['showSubSubject'] && ! empty($summary['sub_subject']))
-                                        <p contenteditable="true" class="text-center editable-effect">{{ $summary['sub_subject'] }}</p>
+                                        @if($previewOptions['showChapter'] && ! empty($summary['chapter']))
+                                        <p contenteditable="true" class="text-center editable-effect">{{ $summary['chapter'] }}</p>
                                         @endif
                                         @if($previewOptions['showTopic'] && ! empty($summary['topic']))
                                         <p contenteditable="true" class="text-center editable-effect">{{ $summary['topic'] }}</p>
@@ -441,7 +441,7 @@
                                             <div class="bg-gray-100 p-2 rounded  flex justify-between items-center my-1">
                                                 <span class="bangla">বিষয়ের নাম</span>
                                                 <label class="relative inline-flex items-center  cursor-pointer">
-                                                    <input type="checkbox" class="sr-only peer" wire:model.live="previewOptions.showSubSubject">
+                                                    <input type="checkbox" class="sr-only peer" wire:model.live="previewOptions.showChapter">
                                                     <div class="w-11 h-6 bg-gray-200 rounded-full peerdark:peer-focus:ring-emerald-800 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-emerald-600"></div>
                                                 </label>
                                             </div>

--- a/resources/views/livewire/teacher/question-paper.blade.php
+++ b/resources/views/livewire/teacher/question-paper.blade.php
@@ -46,8 +46,8 @@
                     @endif
                     <div class="relative">
                         <p contenteditable="true" class="text-center text-lg">{{ $subject->name }}</p>
-                        @if($previewOptions['showSubSubject'] && ! empty($subSubject->name))
-                            <p contenteditable="true" class="text-center">{{ $subSubject->name }}</p>
+                        @if($previewOptions['showChapter'] && ! empty($chapter->name))
+                            <p contenteditable="true" class="text-center">{{ $chapter->name }}</p>
                         @endif
                         @if($previewOptions['showTopic'] && $topics->isNotEmpty())
                             <p class="text-center text-sm">({{ $topics->pluck('name')->implode(', ') }})</p>
@@ -267,7 +267,7 @@
                         <div>
                             <div class="bg-gray-100 p-2 rounded  flex justify-between items-center my-1"><span class="bangla">বিষয়ের নাম</span>
                                 <label class="relative inline-flex items-center  cursor-pointer">
-                                    <input type="checkbox" class="sr-only peer" wire:model.live="previewOptions.showSubSubject">
+                                    <input type="checkbox" class="sr-only peer" wire:model.live="previewOptions.showChapter">
                                     <div class="w-11 h-6 bg-gray-200 rounded-full peerdark:peer-focus:ring-emerald-800 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-emerald-600"></div>
                                 </label>
                             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,9 +16,9 @@ use App\Livewire\Admin\ExamCategory\Index as ExamCategoryIndex;
 use App\Livewire\Admin\Subjects\Index as SubjectIndex;
 use App\Livewire\Admin\Subjects\Create as SubjectCreate;
 use App\Livewire\Admin\Subjects\Edit as SubjectEdit;
-use App\Livewire\Admin\SubSubjects\Index as SubSubjectIndex;
-use App\Livewire\Admin\SubSubjects\Create as SubSubjectCreate;
-use App\Livewire\Admin\SubSubjects\Edit as SubSubjectEdit;
+use App\Livewire\Admin\Chapters\Index as ChapterIndex;
+use App\Livewire\Admin\Chapters\Create as ChapterCreate;
+use App\Livewire\Admin\Chapters\Edit as ChapterEdit;
 use App\Livewire\Admin\Topics\Index as TopicIndex;
 use App\Livewire\Admin\Topics\Create as TopicCreate;
 use App\Livewire\Admin\Topics\Edit as TopicEdit;
@@ -62,8 +62,8 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     // Subjects
     Route::get('/admin/subjects', SubjectIndex::class)->name('admin.subjects.index');
 
-    // Sub Subjects
-    Route::get('/admin/sub-subjects', SubSubjectIndex::class)->name('admin.sub-subjects.index');
+    // Chapters
+    Route::get('/admin/chapters', ChapterIndex::class)->name('admin.chapters.index');
 
     // Topics
     Route::get('/admin/topics', TopicIndex::class)->name('admin.topics.index');

--- a/tests/Feature/QuestionTopicOptionalTest.php
+++ b/tests/Feature/QuestionTopicOptionalTest.php
@@ -4,7 +4,7 @@ namespace Tests\Feature;
 
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use App\Models\{User, Subject, SubSubject, Question};
+use App\Models\{User, Subject, Chapter, Question};
 use Illuminate\Support\Facades\Validator;
 
 class QuestionTopicOptionalTest extends TestCase
@@ -18,7 +18,7 @@ class QuestionTopicOptionalTest extends TestCase
 
         $question = Question::create([
             'subject_id' => $subject->id,
-            'sub_subject_id' => null,
+            'chapter_id' => null,
             'topic_id' => null,
             'title' => 'What is 2 + 2?',
             'difficulty' => 'easy',
@@ -27,28 +27,28 @@ class QuestionTopicOptionalTest extends TestCase
 
         $this->assertDatabaseHas('questions', [
             'id' => $question->id,
-            'sub_subject_id' => null,
+            'chapter_id' => null,
             'topic_id' => null,
         ]);
     }
 
-    public function test_topic_is_required_when_sub_subject_selected(): void
+    public function test_topic_is_required_when_chapter_selected(): void
     {
         $user = User::factory()->create();
         $subject = Subject::create(['name' => 'Math']);
-        $sub = SubSubject::create(['subject_id' => $subject->id, 'name' => 'Algebra']);
+        $sub = Chapter::create(['subject_id' => $subject->id, 'name' => 'Algebra']);
 
         $validator = Validator::make([
             'subject_id' => $subject->id,
-            'sub_subject_id' => $sub->id,
+            'chapter_id' => $sub->id,
             'topic_id' => null,
             'title' => 'What is 2 + 2?',
             'difficulty' => 'easy',
             'user_id' => $user->id,
         ], [
             'subject_id' => 'required|exists:subjects,id',
-            'sub_subject_id' => 'nullable|exists:sub_subjects,id',
-            'topic_id' => 'required_with:sub_subject_id|nullable|exists:topics,id',
+            'chapter_id' => 'nullable|exists:chapters,id',
+            'topic_id' => 'required_with:chapter_id|nullable|exists:topics,id',
             'title' => 'required|string',
             'difficulty' => 'required',
             'user_id' => 'required',


### PR DESCRIPTION
### Motivation
- Standardize domain naming by replacing all occurrences of `SubSubject`/`sub_subject` with `Chapter`/`chapter` so code, DB schema and UI labels are consistent.
- Ensure relationships, validation rules and generation criteria use `chapter_id` and `chapters` table to match the new naming.

### Description
- Renamed model and related files: `app/Models/SubSubject.php` → `app/Models/Chapter.php` and updated `Question`, `Topic`, `Subject`, and `QuestionSet` relations and fillables to use `chapter`/`chapter_id` where appropriate.
- Renamed migrations and schema changes from `sub_subjects`/`sub_subject_id` to `chapters`/`chapter_id` and updated the add/drop foreign key logic in the topic and question migrations.
- Moved and updated Livewire admin components and views from `Admin/SubSubjects` and `livewire/admin/sub-subjects` to `Admin/Chapters` and `livewire/admin/chapters`, and updated namespaces, component logic, events and TomSelect wiring to `chapter`/`chapters` naming.
- Adjusted other Livewire/teacher/student components, Blade templates, route imports and route paths, and updated the feature test `tests/Feature/QuestionTopicOptionalTest.php` to use `Chapter`/`chapter_id`.

### Testing
- Ran PHP syntax checks (`php -l` across `app`, `database`, `routes`, `tests`) and no syntax errors were reported for the modified PHP files. 
- Attempted to run the feature test `php artisan test tests/Feature/QuestionTopicOptionalTest.php`, but execution failed due to a missing test environment dependency (`vendor/autoload.php` not present), so PHPUnit could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c57334f9c48321b72fdf3ee75366ea)